### PR TITLE
Accept empty params

### DIFF
--- a/lib/flappi/utils/param_types.rb
+++ b/lib/flappi/utils/param_types.rb
@@ -3,8 +3,7 @@ module Flappi
     module ParamTypes
 
       def validate_param(src, type)
-        # puts "validate_param #{src}, type #{type.to_s}"
-        return nil if src.nil?
+        return true if src.blank?
 
         case type&.to_s
           when nil

--- a/test/param_types_test.rb
+++ b/test/param_types_test.rb
@@ -9,6 +9,11 @@ class Flappi::VersionsTest < MiniTest::Test
     end
 
     context 'validate_param' do
+      should 'accept empty param' do
+        assert @param_types_test.validate_param(nil, 'Wibble')
+        assert @param_types_test.validate_param('', 'Wibble')
+      end
+
       should 'accept anything for nil type' do
         assert @param_types_test.validate_param('anything', nil)
       end


### PR DESCRIPTION
@richdrich Please tell me if we can do it that way, or which concerns you might see.

This is also a bugfix in regard to [that Obeya story](https://beta.getobeya.com/#t/SS_Reader_V1.0.2_-_Setting_in_this_financial_year_.../zC54Lj8ZJL2TEZFoQ)

The thing is, most clients will send the param 'key' always, usually with a value but sometimes also without a value. (Example `http://url.com/?start_date=2012-01-01&end_date=`) 

This might look odd, but is in practice sadly often the case. Example `$.ajax('http://url.com/documents?search=' + my_search_string)`(string can be empty too)

Also, sometimes it can have a meaning. In the example above, a client tells us 'no end date is given'. Within the investapp, we set the end date then to the portfolio today.

Let me know if you want to handle the param validation that loose, or if I [and other client devs] have to strip out empty params on the client side.

PS. Currently the production mobile app is broken

