### PR TITLE
Set default params when nil or empty string

### DIFF
--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -76,12 +76,14 @@ module Flappi
       end
 
       # Merge in default values where one is defined and we don't have an actual parameter
-      controller.params.merge! Hash[controller.endpoint_info[:params].select do |defined_param|
-        !controller.params.key?(defined_param[:name]) && defined_param[:default]
-      end.
-      map do |defined_param|
-        [defined_param[:name], defined_param[:default]]
-      end]
+      controller.params.merge! Hash[
+        controller.endpoint_info[:params].select do |defined_param|
+          param = controller.params.dig(defined_param[:name])
+          (param.nil? || param == "") && defined_param[:default]
+        end.map do |defined_param|
+          [defined_param[:name], defined_param[:default]]
+        end
+      ]
 
       Flappi::Utils::Logger.d "After default params=#{controller.params}"
 

--- a/lib/flappi/utils/param_types.rb
+++ b/lib/flappi/utils/param_types.rb
@@ -3,7 +3,7 @@ module Flappi
     module ParamTypes
 
       def validate_param(src, type)
-        return false if src.nil? || src == ""
+        return false if src.nil?
 
         case type&.to_s
           when nil

--- a/lib/flappi/utils/param_types.rb
+++ b/lib/flappi/utils/param_types.rb
@@ -3,7 +3,7 @@ module Flappi
     module ParamTypes
 
       def validate_param(src, type)
-        return true if src.blank?
+        return false if src.nil? || src == ""
 
         case type&.to_s
           when nil

--- a/test/param_types_test.rb
+++ b/test/param_types_test.rb
@@ -25,8 +25,9 @@ class Flappi::VersionsTest < MiniTest::Test
       end
 
       should 'reject empty param' do
+        assert @param_types_test.validate_param('', 'Wibble')
         refute @param_types_test.validate_param(nil, 'Wibble')
-        refute @param_types_test.validate_param('', 'Wibble')
+        refute @param_types_test.validate_param('', 'Date')
       end
 
       should 'reject invalid values for boolean type' do

--- a/test/param_types_test.rb
+++ b/test/param_types_test.rb
@@ -9,10 +9,6 @@ class Flappi::VersionsTest < MiniTest::Test
     end
 
     context 'validate_param' do
-      should 'accept empty param' do
-        assert @param_types_test.validate_param(nil, 'Wibble')
-        assert @param_types_test.validate_param('', 'Wibble')
-      end
 
       should 'accept anything for nil type' do
         assert @param_types_test.validate_param('anything', nil)
@@ -26,6 +22,11 @@ class Flappi::VersionsTest < MiniTest::Test
         assert @param_types_test.validate_param('N', 'BOOLEAN')
         assert @param_types_test.validate_param(1, 'BOOLEAN')
         assert @param_types_test.validate_param(0, 'BOOLEAN')
+      end
+
+      should 'reject empty param' do
+        refute @param_types_test.validate_param(nil, 'Wibble')
+        refute @param_types_test.validate_param('', 'Wibble')
       end
 
       should 'reject invalid values for boolean type' do


### PR DESCRIPTION
- [x] revert empty parameter changes from PR #2 
- [x] Preset empty param (‘’ and nil) with default values

I wasn’t quite aware of that flappi even queries the db directly, based on the given params (response_builder.rb:37)

This of course fails when the date params are valid as empty string “”.

So I reverted the changes to accept empty parameters from PR #2 .
Instead, we set now the default values when a parameter was not set (nil), or set to empty string (‘’).

Example:
In case of a `...?end_date=`, the date would be set to its default value `today`.