### PR TITLE
Rails 5 fixes

### DIFF
--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -58,11 +58,10 @@ module Flappi
         controller.requested_version = normalised_version
       end
 
-      actual_params = controller.params
       defined_params = controller.endpoint_info[:params]
-      apply_default_parameters actual_params, defined_params
+      apply_default_parameters controller.params, defined_params
 
-      validate_error, fail_code = validate_parameters(actual_params, defined_params)
+      validate_error, fail_code = validate_parameters(controller.params, defined_params)
       if validate_error
         Flappi::Utils::Logger.w validate_error
         controller.render json: { error: validate_error }.to_json, text: validate_error, status: fail_code || :not_acceptable
@@ -178,7 +177,7 @@ module Flappi
       actual_params.merge! Hash[
                                defined_params.select do |defined_param|
                                  param = actual_params.dig(defined_param[:name])
-                                 (param.nil? || param == '') && defined_param[:default]
+                                 (param.nil? || param == '') && defined_param.key?(:default)
                                end.map do |defined_param|
                                  [defined_param[:name], defined_param[:default]]
                                end

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -129,7 +129,7 @@ module Flappi
         endpoint: {
           title: documenter_definition.endpoint_info[:title] || documenter_definition.endpoint_info[:description],
           description: documenter_definition.endpoint_info[:description] || documenter_definition.endpoint_info[:title],
-          method_name: documenter_definition.endpoint_info[:method],
+          method_name: documenter_definition.endpoint_info[:http_method],
           path: path,
           params: param_docs,
           api_name: definition.name.demodulize,

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -281,8 +281,8 @@ module Flappi
 
     # Define the HTTP method - note however that Rails and the controller is responsible for routing
     # @param v (String) GET, POST, PUT, DELETE
-    def method(v)
-      endpoint_info[:method] = v
+    def http_method(v)
+      endpoint_info[:http_method] = v
     end
 
     # Define the title

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -378,15 +378,18 @@ module Flappi
       def_args = extract_definition_args(args_or_name)
       require_arg def_args, :name
 
-      endpoint_info[:params] <<
-        { name: def_args[:name],
-          type: name_for_type(def_args[:type]),
-          default: def_args[:default],
-          default_doc: def_args[:default_doc],
-          description: def_args[:doc],
-          optional: def_args.key?(:optional) ? def_args[:optional] : true,
-          validation_block: block,
-          fail_code: def_args[:fail_code] }
+      param_def = { name: def_args[:name],
+                    type: name_for_type(def_args[:type]),
+                    default_doc: def_args[:default_doc],
+                    description: def_args[:doc],
+                    optional: def_args.key?(:optional) ? def_args[:optional] : true,
+                    validation_block: block,
+                    fail_code: def_args[:fail_code] }
+
+      # options that take nil
+      param_def[:default] = def_args[:default] if def_args.key?(:default)
+
+      endpoint_info[:params] << param_def
     end
 
     # Define a query to be used to retrieve the source object for the response.

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -400,5 +400,12 @@ module Flappi
     def query(&block)
       @delegate.query(block)
     end
+
+    # From inside a query, return an error
+    # @param status_code (Integer) an HTTP status code to return
+    # @param msg (String) a message to return
+    def return_error(status_code, msg)
+      @delegate.return_error(status_code, msg) if @delegate.respond_to?(:return_error)
+    end
   end
 end

--- a/lib/flappi/doc_builder.rb
+++ b/lib/flappi/doc_builder.rb
@@ -34,7 +34,12 @@ module Flappi
     def field(*args_or_name, _block)
       def_args = extract_definition_args(args_or_name)
       require_arg def_args, :name
+
       return unless version_wanted(def_args)
+      if def_args.key?(:when)
+        ignore = !def_args[:when] rescue false # The when clause can call undefined code at doc time
+        return if ignore
+      end
 
       # handle dynamic field names by bracketing either 'doc_name' or the word 'dynamic'
       # with an underscore

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -27,6 +27,7 @@ module Flappi
       # puts "response_builder::build, class= #{self.class} self="; pp self;
 
       base_object = nil
+      @status_code = nil
       if @query_block
         # We have a query block defined, call it to get the model object
         base_object = @query_block.call(controller_params)
@@ -38,6 +39,10 @@ module Flappi
         # which we should have by virtue of being mixed into the controller
         base_object = options[:type].where(controller_params)
       end
+
+      # If return_error called, return a struct
+      return OpenStruct.new(status_code: @status_code, status_message: @status_message) if @status_code
+
 
       @response_tree = new_h
       @put_stack = [@response_tree]
@@ -238,6 +243,11 @@ module Flappi
 
     def query(block)
       @query_block = block
+    end
+
+    def return_error(status_code, msg)
+      @status_code = status_code
+      @status_message = msg
     end
 
     # private

--- a/test/builder_factory_test.rb
+++ b/test/builder_factory_test.rb
@@ -6,7 +6,7 @@ class ::Flappi::BuilderFactoryTest < MiniTest::Test
   context 'validate_parameters' do
     setup do
       @defined_parameters = [
-        { name: 'a' , fail_code: 422},
+        { name: 'a', fail_code: 422 },
         { name: 'b', type: Float },
         { name: 'c', validation_block: ->(p) { (p.to_i / 10) == 3 ? nil : "c(#{p}) must be 3 * 10ⁿ" } },
         { name: 'd', type: Date, optional: true }
@@ -41,20 +41,21 @@ class ::Flappi::BuilderFactoryTest < MiniTest::Test
     setup do
       @defined_parameters = [
         { name: 'a' },
-        { name: 'b', type: Float, default: 888.88 }
+        { name: 'b', type: Float, default: 888.88 },
+        { name: 'c', type: :boolean_type, default: false }
       ]
     end
 
     should 'put defaults into actuals' do
       actual_params = { 'a' => 'hello' }
       Flappi::BuilderFactory.apply_default_parameters(actual_params, @defined_parameters)
-      assert_equal({ 'a' => 'hello', 'b' => 888.88 }, actual_params)
+      assert_equal({ 'a' => 'hello', 'b' => 888.88, 'c' => false }, actual_params)
     end
 
     should 'apply default when parameter empty' do
-      actual_params = { 'a' => 'hello', 'b' => '' }
+      actual_params = { 'a' => 'hello', 'b' => '', 'c' => true }
       Flappi::BuilderFactory.apply_default_parameters(actual_params, @defined_parameters)
-      assert_equal({ 'a' => 'hello', 'b' => 888.88 }, actual_params)
+      assert_equal({ 'a' => 'hello', 'b' => 888.88, 'c' => true }, actual_params)
     end
   end
 end

--- a/test/examples/exercise1.rb
+++ b/test/examples/exercise1.rb
@@ -12,9 +12,13 @@ module Examples
       param :extra, type: Integer, doc: 'An extra query parameter', optional: true
       param :defaulted, type: Integer, doc: 'Parameter with default', default: 123
 
-      query do |_params|
-        [{ n: 1, name: 'one' },
-         { n: 2, name: 'two' }]
+      query do |params|
+        if params[:return_error]
+          return_error 422, 'Eek!'
+        else
+          [{ n: 1, name: 'one' },
+           { n: 2, name: 'two' }]
+        end
       end
 
       request_example('/api/examples/exercise?extra=100')

--- a/test/examples/exercise1.rb
+++ b/test/examples/exercise1.rb
@@ -5,7 +5,7 @@ module Examples
 
     def endpoint
       group 'Test_Exercise'
-      method 'GET'
+      http_method 'GET'
       path '/examples/exercise1'
       title 'Exercise API 1'
       description 'Exercise definition DSL #1'

--- a/test/examples/exercise2_versioned.rb
+++ b/test/examples/exercise2_versioned.rb
@@ -5,7 +5,7 @@ module Examples
 
     def endpoint
       group 'Test_Exercise'
-      method 'GET'
+      http_method 'GET'
       path '/examples/exercise2'
       title 'Exercise API 2'
       description 'Exercise definition DSL #2 with versioning'

--- a/test/examples/exercise3_my_method.rb
+++ b/test/examples/exercise3_my_method.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module Examples
+  module Exercise3MyMethod
+    include Flappi::Definition
+
+    def endpoint
+      group 'Test_Exercise3'
+      method 'POST'
+      path '/examples/exercise3/my_method'
+      title 'Exercise API 3'
+      description 'Exercise definition DSL #3'
+      param :inline, type: Integer, doc: 'Inline param'
+
+      query do |params|
+        { ok: true }
+      end
+
+      response_example(<<~END_EXAMPLE
+      {
+        ok: true
+      }
+      END_EXAMPLE
+      )
+    end
+
+    def respond
+      build do
+        field :ok, type: BOOLEAN
+      end
+    end
+  end
+end

--- a/test/examples/exercise4.rb
+++ b/test/examples/exercise4.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Examples
+  module Exercise3
+    include Flappi::Definition
+
+    def endpoint
+      group 'Test_Exercise'
+      method 'GET'
+      path '/examples/exercise1'
+      title 'Exercise API 3'
+      description 'Exercise definition DSL #3'
+
+      request_example('/api/examples/exercise3')
+      response_example(<<~END_EXAMPLE
+      {
+      }
+      END_EXAMPLE
+      )
+    end
+
+    def respond
+      build do
+        my_field(:a, false)
+        my_field(:b, true)
+      end
+    end
+
+    def my_field(name, how)
+      field "#{name}_not", 100, doc: 'First field (not)', when: !how
+      field "#{name}_how", 100, doc: 'Second field (how)', when: how
+    end
+
+  end
+end

--- a/test/examples/exercise4_doc.rb
+++ b/test/examples/exercise4_doc.rb
@@ -1,0 +1,39 @@
+=begin
+@api {GET} /examples/exercise1.json Exercise API 3
+
+@apiName Exercise3
+@apiGroup Test_Exercise
+@apiVersion 0.0.0
+
+@apiDescription
+  Exercise definition DSL #3
+
+@apiUse OAuthHeaders
+
+
+
+@apiParamExample Request Example
+    {GET} "/api/examples/exercise3"
+
+
+@apiSuccess (200 Success) {String} a_not
+First field (not)
+
+@apiSuccess (200 Success) {String} b_how
+Second field (how)
+
+
+@apiSuccessExample {json} Response Example
+{
+}
+
+
+@apiError (400 Bad Request) {Integer} error
+  Internal error code
+@apiError (400 Bad Request) {Integer} transaction_id
+  Unique identifier for this API transaction.
+@apiError (400 Bad Request) {Integer} reason
+  Detailed error message what went wrong.
+
+@apiUse OauthErrors
+=end

--- a/test/integration/exercise1_response_test.rb
+++ b/test/integration/exercise1_response_test.rb
@@ -79,6 +79,16 @@ module Integration
                        text: 'Parameter extra must be of type Integer',
                        status: :not_acceptable }, controller.last_render_params)
       end
+
+      should 'return an error when provoked' do
+        controller = Examples::Exercise1Controller.new
+        controller.params = { return_error: true }
+        response = controller.show
+
+        assert_equal({ json: '{"error":"Eek!"}',
+                       text: 'Eek!',
+                       status: 422 }, response)
+      end
     end
   end
 end

--- a/test/integration/exercise2_doco_test.rb
+++ b/test/integration/exercise2_doco_test.rb
@@ -8,7 +8,7 @@ require_relative '../examples/exercise_model'
 require_relative '../examples/exercise2_versioned'
 
 module Integration
-  class Exercise2ResponseTest < MiniTest::Test
+  class Exercise2DocoTest < MiniTest::Test
     context 'Documentation of Exercise2' do
       setup do
         Flappi.configure do |conf|

--- a/test/integration/exercise3_response_test.rb
+++ b/test/integration/exercise3_response_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+require 'pp'
+
+require_relative '../examples/exercise3_my_method'
+require_relative '../examples/v2_version_plan'
+require_relative '../examples/exercise_model'
+
+module Examples
+  class Exercise3Controller
+    attr_accessor :params
+    attr_accessor :last_render_params
+
+    def my_method
+      Flappi.build_and_respond(self, :my_method)
+    end
+
+    def request
+      OpenStruct.new(query_parameters: params, raw_post: 'This is raw post data')
+    end
+
+    def respond_to
+      yield JsonFormatter.new
+    end
+
+    def render(params)
+      self.last_render_params = params
+    end
+
+  end
+end
+
+module Integration
+  class Exercise3ResponseTest < MiniTest::Test
+    context 'Response to Exercise3' do
+
+      should 'respond with ok to posted data' do
+        controller = Examples::Exercise3Controller.new
+        controller.params = { required: 2.718, version: 'V2.1.0-mobile' }
+        response = controller.my_method
+
+        assert_equal({ json: { 'ok' => true },
+                       status: :ok },
+                     response)
+      end
+
+    end
+  end
+end

--- a/test/integration/exercise4_doco_test.rb
+++ b/test/integration/exercise4_doco_test.rb
@@ -3,10 +3,10 @@ require_relative '../test_helper'
 
 require 'pp'
 
-require_relative '../examples/exercise1'
+require_relative '../examples/exercise4'
 
 module Integration
-  class Exercise1DocoTest < MiniTest::Test
+  class Exercise3DocoTest < MiniTest::Test
     context 'Documentation of Exercise1' do
       setup do
         Flappi.configure do |conf|
@@ -15,11 +15,11 @@ module Integration
       end
 
       should 'document our endpoint' do
-        doc_data = ::Flappi::BuilderFactory.document(::Examples::Exercise1, nil)
+        doc_data = ::Flappi::BuilderFactory.document(::Examples::Exercise3, nil)
         doc_text = ::Flappi::ApiDocFormatter.format_to_text(doc_data)
 
-        expected_doc_text = File.read('test/examples/exercise1_doc.rb')
-        # File.write 'test/examples/NEW_exercise1_doc.rb', doc_text
+        expected_doc_text = File.read('test/examples/exercise4_doc.rb')
+        # File.write 'test/examples/NEW_exercise4_doc.rb', doc_text
         assert_equal expected_doc_text.to_s, doc_text.to_s
       end
     end

--- a/test/integration/exercise4_response_test.rb
+++ b/test/integration/exercise4_response_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+require 'pp'
+
+require_relative '../examples/exercise4'
+
+module Examples
+  class Exercise3Controller
+    attr_accessor :params
+    attr_accessor :last_render_params
+
+    def initialize
+      self.params = {}
+    end
+
+    def show
+      Flappi.build_and_respond(self)
+    end
+
+    def request
+      OpenStruct.new(query_parameters: params)
+    end
+
+    def respond_to
+      yield JsonFormatter.new
+    end
+
+    def render(params)
+      self.last_render_params = params
+    end
+  end
+end
+
+module Integration
+  class Exercise3ResponseTest < MiniTest::Test
+    context 'Response to Exercise3' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'respond with a composed block' do
+        response = Examples::Exercise3Controller.new.show
+
+        assert_equal({ json: { "a_not"=>100, "b_how"=>100 },
+                       status: :ok },
+                     response)
+      end
+    end
+  end
+end

--- a/test/response_builder_test.rb
+++ b/test/response_builder_test.rb
@@ -190,7 +190,7 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
           end
 
           assert_equal({ 'links' => { 'self' => 'http://server/test/123/endpoint',
-                                      'other' => 'http://server/test/other_endpoint' } },
+                                      'other' => 'http://server/test/other_endpoint?extra=456' } },
                        built_response)
         end
       end
@@ -318,10 +318,11 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
         setup do
           @response_builder.controller_url = 'http://server/test/123/endpoint'
           @response_builder.source_definition.path '/:portfolio_id/endpoint'
+          @response_builder.controller_query_parameters = {}
         end
 
         should 'work on own path where no query params' do
-          assert_equal 'http://server/test/123/endpoint', @response_builder.send(:expand_link_path, '/:portfolio_id/endpoint', {}, true)
+          assert_equal 'http://server/test/123/endpoint', @response_builder.send(:expand_self_path, '/:portfolio_id/endpoint')
         end
 
         should 'work on own path with query params' do
@@ -329,7 +330,7 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
           @response_builder.controller_params.merge @response_builder.controller_query_parameters
 
           assert_equal 'http://server/test/123/endpoint?a=1&other=test',
-                       @response_builder.send(:expand_link_path, '/:portfolio_id/endpoint', { a: '1', other: 'test' }, true)
+                       @response_builder.send(:expand_self_path, '/:portfolio_id/endpoint')
         end
 
         should 'work on path with replaceable query params' do
@@ -337,13 +338,28 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
           @response_builder.controller_params.merge @response_builder.controller_query_parameters
 
           assert_equal 'http://server/test/123/endpoint?b=88',
-                       @response_builder.send(:expand_link_path, '/:portfolio_id/endpoint?b=88',
-                                              { a: '1', other: 'test', b: 100 }, false)
+                       @response_builder.send(:expand_link_path, '/:portfolio_id/endpoint?b=88')
         end
 
         should 'work on referenced path where no query params' do
           assert_equal 'http://server/test/portfolios/123/ref',
-                       @response_builder.send(:expand_link_path, '/portfolios/:portfolio_id/ref', {}, true)
+                       @response_builder.send(:expand_link_path, '/portfolios/:portfolio_id/ref')
+        end
+
+        should 'work with a substitutable query param as Rails 4' do
+          @response_builder.controller_params = { 'consolidated' => false, 'portfolio_id' => 123 }
+          @response_builder.controller_query_parameters = { consolidated: false }
+
+          assert_equal 'http://server/test/portfolios/123?consolidated=false',
+                       @response_builder.send(:expand_link_path, '/portfolios/:portfolio_id?consolidated=:consolidated')
+        end
+
+        should 'work with a substitutable query param as Rails 5 (params = symbol hash)' do
+          @response_builder.controller_params = { consolidated: false, portfolio_id: 123 }
+          @response_builder.controller_query_parameters = { consolidated: false }
+
+          assert_equal 'http://server/test/portfolios/123?consolidated=false',
+                       @response_builder.send(:expand_link_path, '/portfolios/:portfolio_id?consolidated=:consolidated')
         end
       end
 


### PR DESCRIPTION
Issues found with rails 5:
- link expansion was only coincidentally working on Rails 4 +. refactor this and simplify
- when a parameter placeholder is used in a link, always try and substitute it
- and hence require that the parameter exist or is defaulted

Rename 'Definition#method' to 'Definition#http_method' => note this is a breaking change