### PR TITLE
[User API] Self URL in API response should reflect the params used

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Metrics/MethodLength:
   Max: 40
 
 Metrics/AbcSize:
-  Max: 40
+  Max: 50
 
 Metrics/CyclomaticComplexity:
   Max: 15

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -16,29 +16,39 @@ module Flappi
         [DocumentingStub.new]
       end
 
-      # rubocop:disable Style/MethodMissing
-      def method_missing(_meth_id, *_args, &_block)
-        # puts "Note: #{_meth_id.id2name} missing, called from stub"
-        DocumentingStub.new
+      def method_missing(meth_name, *args)
+        return DocumentingStub.new unless [:to_ary, :method_missing, :respond_to_missing?].include? meth_name
+        super
       end
 
-      def self.method_missing(_meth_id, *_args, &_block)
-        # puts "Note: class.#{_meth_id.id2name} missing, called from stub"
-        DocumentingStub.new
+      def respond_to_missing?(method_name, _include_private = false)
+        ![:to_ary, :method_missing, :respond_to_missing?].include?(method_name) || super
+      end
+
+      def self.method_missing(meth_name, *_args, &_block)
+        return DocumentingStub.new unless [:to_ary, :method_missing, :respond_to_missing?].include? meth_name
+        super
+      end
+
+      def self.respond_to_missing?(method_name, _include_private = false)
+        ![:method_missing, :respond_to_missing?].include?(method_name) || super
       end
     end
 
     class DefDocumenter
-      def method_missing(_meth_id, *_args, &_block)
-        # puts "Note: #{_meth_id.id2name} missing"
-        DocumentingStub.new
+      def method_missing(meth_name, *args)
+        return DocumentingStub.new unless [:method_missing, :respond_to_missing?].include? meth_name
+        super
+      end
+
+      def respond_to_missing?(method_name, _include_private = false)
+        ![:method_missing, :respond_to_missing?].include?(method_name) || super
       end
     end
-    # rubocop:enable Style/MethodMissing
 
     # Call me from a controller to build the appropriate API response
     # and return it
-    def self.build_and_respond(controller, method=nil)
+    def self.build_and_respond(controller, method = nil)
       definition_klass, endpoint_name, full_version = locate_definition(controller, method)
 
       load_controller(controller, definition_klass, endpoint_name)
@@ -61,6 +71,7 @@ module Flappi
 
       defined_params = controller.endpoint_info[:params]
       apply_default_parameters controller.params, defined_params
+      process_parameters controller.params, defined_params
 
       validate_error, fail_code = validate_parameters(controller.params, defined_params)
       if validate_error
@@ -173,6 +184,15 @@ module Flappi
       end
 
       nil
+    end
+
+    # process parameters through any processors defined on the param
+    def self.process_parameters(actual_params, defined_params)
+      defined_params.each do |defined_param|
+        if defined_param[:processor_block]
+          actual_params[defined_param[:name]] = defined_param[:processor_block].call(actual_params[defined_param[:name]])
+        end
+      end
     end
 
     # Merge in default values where one is defined and we don't have an actual parameter

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -63,10 +63,10 @@ module Flappi
 
     # @private
     def supported_versions
-      unless @version_rule
-        version_plan.available_version_definitions
-      else
+      if @version_rule
         version_plan.expand_version_rule(@version_rule)
+      else
+        version_plan.available_version_definitions
       end
     end
 
@@ -349,6 +349,9 @@ module Flappi
     # Define an input parameter (inline or query string)
     # This is used to document and validate the parameters.
     #
+    # Chain processor &block to this to define a parameter processor
+    #  and/or validator &block for define a parameter validator
+    #
     # @overload param(name, options={})
     #   Define a named parameter
     #   @param name (String) the name of the parameter
@@ -361,6 +364,7 @@ module Flappi
     #   @yield A block that will be called to validate the parameter
     #   @yieldparam  [Object] param the actual parameter value to validate
     #   @yieldreturn [String] nil if the parameter is valid, else a failure message
+    #   @return [ParamProcessor] chain this with processor or validator
     #
     # @overload param(options={})
     #   Define a parameter
@@ -374,6 +378,7 @@ module Flappi
     #   @yield A block that will be called to validate the parameter
     #   @yieldparam  [Object] param the actual parameter value to validate
     #   @yieldreturn [String] nil if the parameter is valid, else a failure message
+    #   @return [ParamProcessor] chain this with processor or validator
     def param(*args_or_name, &block)
       def_args = extract_definition_args(args_or_name)
       require_arg def_args, :name
@@ -390,6 +395,8 @@ module Flappi
       param_def[:default] = def_args[:default] if def_args.key?(:default)
 
       endpoint_info[:params] << param_def
+
+      ParamProcessor.new(param_def)
     end
 
     # Define a query to be used to retrieve the source object for the response.

--- a/lib/flappi/param_processor.rb
+++ b/lib/flappi/param_processor.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Flappi
+  class ParamProcessor
+    def initialize(param_def)
+      @param_def = param_def
+    end
+
+    # Call block to process a parameter
+    #
+    #   @yield A block that will be called to process the parameter
+    #   @yieldparam  [Object] param the actual parameter value before processing
+    #   @yieldreturn [String] the processed parameter
+    def processor(&block)
+      @param_def[:processor_block] = block
+      self
+    end
+
+    # Call block to validate a parameter
+    #
+    #   @yield A block that will be called to validate the parameter
+    #   @yieldparam  [Object] param the actual parameter value to validate
+    #   @yieldreturn [String] nil if the parameter is valid, else a failure message
+    def validator(&block)
+      @param_def[:validation_block] = block
+      self
+    end
+  end
+end

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -43,7 +43,6 @@ module Flappi
       # If return_error called, return a struct
       return OpenStruct.new(status_code: @status_code, status_message: @status_message) if @status_code
 
-
       @response_tree = new_h
       @put_stack = [@response_tree]
       @hash_stack = []
@@ -60,7 +59,8 @@ module Flappi
 
       links = Hash[(@link_defs || []).map do |link_def|
         expanded_link = if link_def[:key] == :self
-                          expand_self_path(source_definition.endpoint_info[:path])
+                          expand_self_path(source_definition.endpoint_info[:path],
+                                           source_definition.endpoint_info[:params].map { |p| p[:name].to_sym })
                         else
                           expand_link_path(link_def[:path])
                         end
@@ -318,15 +318,14 @@ module Flappi
       controller_url[0...matches.begin(0)]
     end
 
-    def expand_self_path(path)
-      # puts "expand_self_path path=#{path}, controller_query_parameters=#{controller_query_parameters}, controller_params=#{controller_params}"
+    def expand_self_path(path, defined_param_names)
+      # puts "expand_self_path path=#{path}, defined_param_names=#{defined_param_names}, controller_params=#{controller_params}"
       subst_uri, used_params = substitute_link_path_params(path)
 
-      query_params = controller_query_parameters.clone
-      query_params.delete_if { |k, _v| used_params.include? k.to_sym }
+      query_params = controller_params.clone
+      query_params.delete_if { |k, _v| used_params.include?(k.to_sym) || !defined_param_names.include?(k.to_sym) }
 
       src_query_hash = CGI.parse(subst_uri.query || '').with_indifferent_access
-      # puts "src_query_hash=#{src_query_hash}, query_params=#{query_params}"
       subst_query = src_query_hash.merge(query_params)
 
       expanded = expand_uri_with_host(subst_uri)
@@ -335,7 +334,7 @@ module Flappi
     end
 
     def expand_link_path(path)
-      # puts "expand_link_path path=#{path}, controller_query_parameters=#{controller_query_parameters}, controller_params=#{controller_params}"
+      # puts "expand_link_path path=#{path}, controller_params=#{controller_params}"
       subst_uri, _used_params = substitute_link_path_params(path)
 
       expanded = expand_uri_with_host(subst_uri)

--- a/test/examples/exercise1.rb
+++ b/test/examples/exercise1.rb
@@ -9,7 +9,10 @@ module Examples
       path '/examples/exercise1'
       title 'Exercise API 1'
       description 'Exercise definition DSL #1'
-      param :extra, type: Integer, doc: 'An extra query parameter', optional: true
+      param(:extra, type: Integer, doc: 'An extra query parameter', optional: true).processor do |value|
+        value || 1234
+      end
+
       param :defaulted, type: Integer, doc: 'Parameter with default', default: 123
 
       query do |params|
@@ -21,17 +24,19 @@ module Examples
         end
       end
 
+      link :other, 'other/:defaulted/other_api?extra=:extra'
+      link :self
+
       request_example('/api/examples/exercise?extra=100')
-      response_example(<<~END_EXAMPLE
-      {
-        extra_plus_1: 101,
-        rows: [
-          { n: 1, name: 'one' },
-          { n: 2, name: 'two' }
-        ]
-      }
+      response_example <<~END_EXAMPLE
+        {
+          extra_plus_1: 101,
+          rows: [
+            { n: 1, name: 'one' },
+            { n: 2, name: 'two' }
+          ]
+        }
       END_EXAMPLE
-                      )
     end
 
     def respond

--- a/test/examples/exercise3_my_method.rb
+++ b/test/examples/exercise3_my_method.rb
@@ -11,16 +11,15 @@ module Examples
       description 'Exercise definition DSL #3'
       param :inline, type: Integer, doc: 'Inline param'
 
-      query do |params|
+      query do
         { ok: true }
       end
 
-      response_example(<<~END_EXAMPLE
+      response_example <<~END_EXAMPLE
       {
         ok: true
       }
       END_EXAMPLE
-      )
     end
 
     def respond

--- a/test/examples/exercise4.rb
+++ b/test/examples/exercise4.rb
@@ -11,11 +11,10 @@ module Examples
       description 'Exercise definition DSL #4'
 
       request_example('/api/examples/exercise4')
-      response_example(<<~END_EXAMPLE
+      response_example <<~END_EXAMPLE
       {
       }
       END_EXAMPLE
-      )
     end
 
     def respond
@@ -29,6 +28,5 @@ module Examples
       field "#{name}_not", 100, doc: 'First field (not)', when: !how
       field "#{name}_how", 100, doc: 'Second field (how)', when: how
     end
-
   end
 end

--- a/test/integration/exercise1_response_test.rb
+++ b/test/integration/exercise1_response_test.rb
@@ -19,7 +19,7 @@ module Examples
     end
 
     def request
-      OpenStruct.new(query_parameters: params)
+      OpenStruct.new(query_parameters: params, url: 'http://test.api/exercise1')
     end
 
     def respond_to
@@ -39,48 +39,56 @@ module Integration
         Flappi.configure do |conf|
           conf.version_plan = nil
         end
+
+        @controller = Examples::Exercise1Controller.new
       end
 
       should 'respond with a composed block' do
-        response = Examples::Exercise1Controller.new.show
+        response = @controller.show
 
-        assert_equal({ 'extra' => 150, 'defaulted' => 123, 'data' => [{ 'n' => 1, 'name' => 'one' }, { 'n' => 2, 'name' => 'two' }] },
-                       response)
+        assert_equal({ 'extra' => 150,
+                       'defaulted' => 123,
+                       'data' => [{ 'n' => 1, 'name' => 'one' }, { 'n' => 2, 'name' => 'two' }],
+                       'links' => { 'other' => 'http://test.api/exercise1/other/123/other_api?extra=50',
+                                    'self' => 'http://test.api/exercise1/examples/exercise1?defaulted=123&extra=50' } },
+                     response)
       end
 
       should 'respond with a composed block when no param' do
-        controller = Examples::Exercise1Controller.new
-        controller.params = {}
-        response = controller.show
+        @controller.params = {}
+        response = @controller.show
 
-        assert_equal({ 'extra' => 100, 'defaulted' => 123, 'data' => [{ 'n' => 1, 'name' => 'one' }, { 'n' => 2, 'name' => 'two' }] },
+        assert_equal({ 'extra' => 1334, 'defaulted' => 123,
+                       'data' => [{ 'n' => 1, 'name' => 'one' },
+                                  { 'n' => 2, 'name' => 'two' }],
+                       'links' => { 'other' => 'http://test.api/exercise1/other/123/other_api?extra=1234',
+                                    'self' => 'http://test.api/exercise1/examples/exercise1?defaulted=123&extra=1234' } },
                      response)
       end
 
       should 'override a default param from query' do
-        controller = Examples::Exercise1Controller.new
-        controller.params = { defaulted: 888 }
-        response = controller.show
+        @controller.params = { defaulted: 888 }
+        response = @controller.show
 
-        assert_equal({ 'extra' => 100, 'defaulted' => 888, 'data' => [{ 'n' => 1, 'name' => 'one' }, { 'n' => 2, 'name' => 'two' }] },
+        assert_equal({ 'extra' => 1234 + 100, 'defaulted' => 888, 'data' => [{ 'n' => 1, 'name' => 'one' }, { 'n' => 2, 'name' => 'two' }],
+                       'links' => { 'other' => 'http://test.api/exercise1/other/888/other_api?extra=1234',
+                                    'self' => 'http://test.api/exercise1/examples/exercise1?defaulted=888&extra=1234' } },
                      response)
       end
 
       should 'detect validation failures' do
-        controller = Examples::Exercise1Controller.new
-        controller.params = { extra: 'Hello!' }
-        response = controller.show
+        @controller.params = { extra: 'Hello!' }
+        response = @controller.show
         refute response
 
         assert_equal({ json: '{"error":"Parameter extra must be of type Integer"}',
                        text: 'Parameter extra must be of type Integer',
-                       status: :not_acceptable }, controller.last_render_params)
+                       status: :not_acceptable }, @controller.last_render_params)
       end
 
       should 'return an error when provoked' do
-        controller = Examples::Exercise1Controller.new
-        controller.params = { return_error: true }
-        response = controller.show
+        @controller.params = { return_error: true }
+        response = @controller.show
 
         assert_equal('Eek!', response.status_message)
         assert_equal(422, response.status_code)

--- a/test/integration/exercise3_response_test.rb
+++ b/test/integration/exercise3_response_test.rb
@@ -27,14 +27,12 @@ module Examples
     def render(params)
       self.last_render_params = params
     end
-
   end
 end
 
 module Integration
   class Exercise3ResponseTest < MiniTest::Test
     context 'Response to Exercise3' do
-
       should 'respond with ok to posted data' do
         controller = Examples::Exercise3Controller.new
         controller.params = { required: 2.718, version: 'V2.1.0-mobile' }
@@ -43,7 +41,6 @@ module Integration
         assert_equal({ 'ok' => true },
                      response)
       end
-
     end
   end
 end

--- a/test/integration/exercise4_response_test.rb
+++ b/test/integration/exercise4_response_test.rb
@@ -44,7 +44,7 @@ module Integration
       should 'respond with a composed block' do
         response = Examples::Exercise4Controller.new.show
 
-        assert_equal({ "a_not"=>100, "b_how"=>100 },
+        assert_equal({ 'a_not' => 100, 'b_how' => 100 },
                      response)
       end
     end

--- a/test/response_builder_test.rb
+++ b/test/response_builder_test.rb
@@ -289,7 +289,7 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
       end
 
       should 'cast_value' do
-        assert_equal nil, @response_builder.cast_value(nil, Flappi::Definition::BOOLEAN, nil)
+        assert_nil @response_builder.cast_value(nil, Flappi::Definition::BOOLEAN, nil)
         assert_equal false, @response_builder.cast_value(false, Flappi::Definition::BOOLEAN, nil)
         assert_equal true, @response_builder.cast_value(1, Flappi::Definition::BOOLEAN, nil)
 
@@ -322,15 +322,15 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
         end
 
         should 'work on own path where no query params' do
-          assert_equal 'http://server/test/123/endpoint', @response_builder.send(:expand_self_path, '/:portfolio_id/endpoint')
+          assert_equal 'http://server/test/123/endpoint', @response_builder.send(:expand_self_path, '/:portfolio_id/endpoint', [])
         end
 
         should 'work on own path with query params' do
           @response_builder.controller_query_parameters = { a: '1', other: 'test' }
-          @response_builder.controller_params.merge @response_builder.controller_query_parameters
+          @response_builder.controller_params.merge! @response_builder.controller_query_parameters
 
           assert_equal 'http://server/test/123/endpoint?a=1&other=test',
-                       @response_builder.send(:expand_self_path, '/:portfolio_id/endpoint')
+                       @response_builder.send(:expand_self_path, '/:portfolio_id/endpoint', [:a, :other])
         end
 
         should 'work on path with replaceable query params' do


### PR DESCRIPTION
to generate the response rather than the params supplied by the API user.

Make the 'params' keyword take a block that does any processing of the param (&test)
Ensure that the processed parameters are used in link statements
Rubocop tidy up