### PR TITLE
Remove quotation to allow free formatting of a request example

### DIFF
--- a/lib/flappi/api_doc_template.rb.erb
+++ b/lib/flappi/api_doc_template.rb.erb
@@ -16,7 +16,7 @@
 <% end %>
 
 @apiParamExample Request Example
-    {<%= endpoint.method_name %>} "<%= endpoint.request_example %>"
+{<%= endpoint.method_name %>} <%= endpoint.request_example %>
 
 <% for response_item in response %>
 @apiSuccess (200 Success) {<%= response_item.type %>} <%= qname_from(response_item.name) %>

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -146,7 +146,7 @@ module Flappi
           api_group: documenter_definition.endpoint_info[:group],
           api_version: documenter_definition.document_as_version(for_version),
           response_example: documenter_definition.endpoint_info[:response_example],
-          request_example: documenter_definition.endpoint_info[:request_example] || path
+          request_example: documenter_definition.endpoint_info[:request_example] || "\"#{path}\""
         },
 
         # Query parameters, etc

--- a/test/examples/exercise1.rb
+++ b/test/examples/exercise1.rb
@@ -30,7 +30,7 @@ module Examples
       link :other, 'other/:defaulted/other_api?extra=:extra'
       link :self
 
-      request_example('/api/examples/exercise?extra=100')
+      request_example('"/api/examples/exercise?extra=100"')
       response_example <<~END_EXAMPLE
         {
           extra_plus_1: 101,

--- a/test/examples/exercise1_doc.rb
+++ b/test/examples/exercise1_doc.rb
@@ -19,7 +19,7 @@
 
 
 @apiParamExample Request Example
-    {GET} "/api/examples/exercise?extra=100"
+{GET} "/api/examples/exercise?extra=100"
 
 
 @apiSuccess (200 Success) {String} extra

--- a/test/examples/exercise2_2.0_doc.rb
+++ b/test/examples/exercise2_2.0_doc.rb
@@ -16,7 +16,7 @@
 
 
 @apiParamExample Request Example
-    {GET} "/examples/exercise2"
+{GET} "/examples/exercise2"
 
 
 @apiSuccess (200 Success) {String} all

--- a/test/examples/exercise4.rb
+++ b/test/examples/exercise4.rb
@@ -11,7 +11,7 @@ module Examples
       title 'Exercise API 4'
       description 'Exercise definition DSL #4'
 
-      request_example('/api/examples/exercise4')
+      request_example('"/api/examples/exercise4"')
       response_example <<~END_EXAMPLE
         {
         }

--- a/test/examples/exercise4_doc.rb
+++ b/test/examples/exercise4_doc.rb
@@ -13,7 +13,7 @@
 
 
 @apiParamExample Request Example
-    {GET} "/api/examples/exercise4"
+{GET} "/api/examples/exercise4"
 
 
 @apiSuccess (200 Success) {String} a_not


### PR DESCRIPTION
In order to allow us to freely format a example, lets remove the default quotation.

Then it allows us to write an example like:
<img width="909" alt="req-example" src="https://user-images.githubusercontent.com/2537026/40310526-64f6aaa0-5d0d-11e8-8d2b-cbcfb9db3249.png">
