### PR TITLE
Support version override

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 500
 
+Metrics/BlockLength:
+  Max: 500
+
 Metrics/LineLength:
   Max: 200
 
@@ -60,6 +63,13 @@ Style/WordArray:
 Layout/TrailingWhitespace:
   Exclude:
     - 'test/examples/*_doc.rb'
+
+Naming/VariableNumber:
+  Enabled: false
+
+Lint/UselessComparison:
+  Exclude:
+    - 'test/**'
 
 Layout/AlignParameters:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,3 +57,6 @@ Style/StringLiterals:
 Layout/TrailingWhitespace:
   Exclude:
     - 'test/examples/*_doc.rb'
+
+Layout/AlignParameters:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,9 @@ Style/FrozenStringLiteralComment:
 Style/StringLiterals:
   Enabled: false
 
+Style/WordArray:
+  Enabled: false
+
 Layout/TrailingWhitespace:
   Exclude:
     - 'test/examples/*_doc.rb'

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.name        = 'flappi'
   s.version     = '0.7.0'
-  s.date        = '2018-05-28'
+  s.date        = '2018-07-17'
   s.summary     = 'Flappi API Builder'
   s.description = 'A flexible DSL-based API builder'
   s.authors     = ['Richard Parratt', 'Sharesight']

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'flappi'
-  s.version     = '0.6.0'
-  s.date        = '2018-05-23'
+  s.version     = '0.7.0'
+  s.date        = '2018-05-28'
   s.summary     = 'Flappi API Builder'
   s.description = 'A flexible DSL-based API builder'
   s.authors     = ['Richard Parratt', 'Sharesight']
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'maxitest'
   s.add_development_dependency 'mocha'
+  # s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake', '>= 12.3'
   s.add_development_dependency 'rubocop', '0.53'
   s.add_development_dependency 'shoulda'

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -230,6 +230,11 @@ module Flappi
 
     def self.render_response_json(controller)
       response_object = controller.respond
+
+      # return 204 no content when no content is given rather than parsing it as either `null` or `{}` with a 200 response.
+      # this is only when you omit the build, eg just `def respond; end`
+      return controller.head :no_content unless response_object
+
       if response_object.respond_to?(:status_code)
         error_info = response_object.status_error_info
         response_hash = error_info.is_a?(String) ? { error: error_info } : { errors: error_info }

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -234,6 +234,7 @@ module Flappi
       # return 204 no content when no content is given rather than parsing it as either `null` or `{}` with a 200 response.
       # this is only when you omit the build, eg just `def respond; end`
       return controller.head :no_content unless response_object
+      return controller.head :no_content if response_object.respond_to?(:status_code) && response_object.status_code == 204
 
       if response_object.respond_to?(:status_code)
         error_info = response_object.status_error_info

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -205,7 +205,7 @@ module Flappi
 
       full_version = controller.params[:version]
 
-      definition_klass = DefinitionLocator.locate_class(endpoint_name)
+      definition_klass = DefinitionLocator.locate_class(endpoint_name, full_version)
       [definition_klass, endpoint_name, full_version]
     end
 

--- a/lib/flappi/common.rb
+++ b/lib/flappi/common.rb
@@ -101,7 +101,7 @@ module Flappi
       version_rule = def_args[:version]
 
       supported_versions = version_plan.expand_version_rule(*version_rule)
-      # puts "version check #{supported_versions} includes #{requested_version}"
+      # puts "version check #{version_rule.inspect} => #{supported_versions} includes #{requested_version}"
       supported_versions.include?(requested_version)
     end
   end

--- a/lib/flappi/config.rb
+++ b/lib/flappi/config.rb
@@ -3,16 +3,12 @@
 module Flappi
   class Config
 
-    attr_reader :definition_paths
+    attr_accessor :definition_paths
     attr_accessor :version_plan
     attr_accessor :doc_target_path
     attr_accessor :doc_target_paths
     attr_accessor :logger_level
     attr_reader :logger_target
-
-    def definition_paths=(v)
-      @definition_paths = v.is_a?(Array) ? v : [v]
-    end
 
     # rubocop:disable Naming/AccessorMethodName
     def set_logger_target(&block)
@@ -23,7 +19,6 @@ module Flappi
     def set_logger_rails
       set_logger_target {|m, l| Rails.logger.send %i[error warn info debug debug][l], m }
     end
-
 
   end
 end

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -409,6 +409,11 @@ module Flappi
       @delegate.query(block)
     end
 
+    # From inside a query, return 204 NO CONTENT
+    def return_no_content
+      @delegate.return_no_content if @delegate.respond_to?(:return_no_content)
+    end
+
     # From inside a query, return an error
     # @param status_code (Integer) an HTTP status code to return
     # @param error_info (Object) a message String or an error hash to return

--- a/lib/flappi/definition_locator.rb
+++ b/lib/flappi/definition_locator.rb
@@ -6,6 +6,7 @@ module Flappi
     def self.locate_class(endpoint_name, version)
       issues = []
 
+      version ||= 'default'
       paths = Flappi.configuration.definition_paths[version]
       raise "Unable to find a definition_path for #{version}." unless paths
 

--- a/lib/flappi/definition_locator.rb
+++ b/lib/flappi/definition_locator.rb
@@ -5,9 +5,13 @@ module Flappi
   module DefinitionLocator
     def self.locate_class(endpoint_name, version)
       issues = []
-      # TODO: error handling for version not having definition_path
+
       paths = Flappi.configuration.definition_paths[version]
+      raise "Unable to find a definition_path for #{version}." unless paths
+
+      # Ensure an array as a definition_path may be a string or array
       paths = paths.is_a?(Array) ? paths : [paths]
+
       paths.each do |path|
         candidate_class = nil
 

--- a/lib/flappi/definition_locator.rb
+++ b/lib/flappi/definition_locator.rb
@@ -3,10 +3,12 @@
 
 module Flappi
   module DefinitionLocator
-    def self.locate_class(endpoint_name)
+    def self.locate_class(endpoint_name, version)
       issues = []
-
-      Flappi.configuration.definition_paths.each do |path|
+      # TODO: error handling for version not having definition_path
+      paths = Flappi.configuration.definition_paths[version]
+      paths = paths.kind_of?(Array) ? paths : [paths]
+      paths.each do |path|
         candidate_class = nil
 
         begin

--- a/lib/flappi/definition_locator.rb
+++ b/lib/flappi/definition_locator.rb
@@ -7,7 +7,7 @@ module Flappi
       issues = []
       # TODO: error handling for version not having definition_path
       paths = Flappi.configuration.definition_paths[version]
-      paths = paths.kind_of?(Array) ? paths : [paths]
+      paths = paths.is_a?(Array) ? paths : [paths]
       paths.each do |path|
         candidate_class = nil
 

--- a/lib/flappi/documenter.rb
+++ b/lib/flappi/documenter.rb
@@ -5,6 +5,8 @@ module Flappi
   class Documenter
     # Call to document all definitions under top_module
     def self.document(top_path, top_module, into_path, for_version, with_formatter)
+      FileUtils.mkdir_p into_path
+
       load_all_modules top_path + '/' + top_module.to_s.underscore, top_module
       defs_to_document = builder_definitions(top_module)
 

--- a/lib/flappi/optional/flappi.rake
+++ b/lib/flappi/optional/flappi.rake
@@ -11,14 +11,14 @@ namespace :flappi do
       target_paths = Flappi.configuration.doc_target_paths || Flappi.configuration.doc_target_path
       target_paths = { '*' => target_paths } unless target_paths.is_a?(Hash)
 
-      Flappi.configuration.definition_paths.each do |path|
-        target_paths.each do |document_version, to_path|
-          Flappi::Documenter.document 'app/controllers',
-                                      path.camelize.constantize,
-                                      to_path,
-                                      document_version,
-                                      Flappi::ApiDocFormatter
-        end
+      target_paths.each do |document_version, to_path|
+        paths = Flappi.configuration.definition_paths[document_version]
+        paths = paths.kind_of?(Array) ? paths : [paths]
+        Flappi::Documenter.document 'app/controllers',
+          paths.first.camelize.constantize,
+          to_path,
+          document_version,
+          Flappi::ApiDocFormatter
       end
     end
   end

--- a/lib/flappi/optional/flappi.rake
+++ b/lib/flappi/optional/flappi.rake
@@ -13,7 +13,7 @@ namespace :flappi do
 
       target_paths.each do |document_version, to_path|
         paths = Flappi.configuration.definition_paths[document_version]
-        paths = paths.kind_of?(Array) ? paths : [paths]
+        paths = paths.is_a?(Array) ? paths : [paths]
         Flappi::Documenter.document 'app/controllers',
           paths.first.camelize.constantize,
           to_path,

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -244,6 +244,10 @@ module Flappi
       @query_block = block
     end
 
+    def return_no_content
+      @status_code = 204
+    end
+
     def return_error(status_code, error_info)
       @status_code = status_code
       @status_error_info = error_info

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -312,7 +312,8 @@ module Flappi
 
     def controller_base_url
       raise 'path not defined in endpoint' unless source_definition.endpoint_info[:path]
-      path_matcher = Regexp.new source_definition.endpoint_info[:path].gsub(/\/:\w+\//, '\/[^\/]+\/')
+      path = source_definition.endpoint_info[:path].gsub(/\/$/, '') # remove trailing slash
+      path_matcher = Regexp.new(path.gsub(/\/:\w+/, '\/[^\/]+')) # converts `/user/:user_id` into `/user/[^\/]+`
 
       # puts "Using matcher #{path_matcher} on #{controller_url}"
       matches = controller_url.match(path_matcher)

--- a/lib/flappi/version_plan.rb
+++ b/lib/flappi/version_plan.rb
@@ -99,17 +99,19 @@ module Flappi
     # Given a version rule (defined against an endpoint), parse this into an array of supported versions
     # (for an endpoint or field)
     # rules are of the form:
-    # equals: version_number (can omit trailing minors or flavours which will be wildcarded)
-    # not: version_number (as above) - not supported yet
-    # before: version_number - not supported yet
-    # after: version_nunber - not supported yet
+    # equals, eq: version_number (can omit trailing minors or flavours which will be wildcarded)
+    # ne: version_number (as above)
+    # after, gt: version_nunber
+    # before, lt: version_number
+    # gte: version_nunber
+    # lte: version_nunber
     def expand_version_rule(*version_rule_args)
       version_rules = Flappi::Utils::ArgUtils.paired_args(*version_rule_args)
 
       supported_versions = []
       version_rules.each do |version_rule|
         case version_rule[0].to_sym
-        when :equals
+        when :equals, :eq
           supported_versions += available_version_definitions.versions_array.select { |av| av == parse_version(version_rule[1]) }
         when :ne
           supported_versions += available_version_definitions.versions_array.reject { |av| av == parse_version(version_rule[1]) }
@@ -117,9 +119,9 @@ module Flappi
           supported_versions += available_version_definitions.versions_array.select { |av| av > parse_version(version_rule[1]) }
         when :before, :lt
           supported_versions += available_version_definitions.versions_array.select { |av| av < parse_version(version_rule[1]) }
-        when :ge
+        when :gte
           supported_versions += available_version_definitions.versions_array.select { |av| av >= parse_version(version_rule[1]) }
-        when :le
+        when :lte
           supported_versions += available_version_definitions.versions_array.select { |av| av <= parse_version(version_rule[1]) }
         else
           raise "Rule type #{version_rule[0]} not supported yet, sorry..."

--- a/lib/flappi/version_plan.rb
+++ b/lib/flappi/version_plan.rb
@@ -111,6 +111,16 @@ module Flappi
         case version_rule[0].to_sym
         when :equals
           supported_versions += available_version_definitions.versions_array.select { |av| av == parse_version(version_rule[1]) }
+        when :ne
+          supported_versions += available_version_definitions.versions_array.reject { |av| av == parse_version(version_rule[1]) }
+        when :after, :gt
+          supported_versions += available_version_definitions.versions_array.select { |av| av > parse_version(version_rule[1]) }
+        when :before, :lt
+          supported_versions += available_version_definitions.versions_array.select { |av| av < parse_version(version_rule[1]) }
+        when :ge
+          supported_versions += available_version_definitions.versions_array.select { |av| av >= parse_version(version_rule[1]) }
+        when :le
+          supported_versions += available_version_definitions.versions_array.select { |av| av <= parse_version(version_rule[1]) }
         else
           raise "Rule type #{version_rule[0]} not supported yet, sorry..."
         end

--- a/lib/flappi/version_plan.rb
+++ b/lib/flappi/version_plan.rb
@@ -103,8 +103,8 @@ module Flappi
     # ne: version_number (as above)
     # after, gt: version_nunber
     # before, lt: version_number
-    # gte: version_nunber
-    # lte: version_nunber
+    # gte, ge: version_nunber
+    # lte, le: version_nunber
     def expand_version_rule(*version_rule_args)
       version_rules = Flappi::Utils::ArgUtils.paired_args(*version_rule_args)
 
@@ -119,9 +119,9 @@ module Flappi
           supported_versions += available_version_definitions.versions_array.select { |av| av > parse_version(version_rule[1]) }
         when :before, :lt
           supported_versions += available_version_definitions.versions_array.select { |av| av < parse_version(version_rule[1]) }
-        when :gte
+        when :gte, :ge
           supported_versions += available_version_definitions.versions_array.select { |av| av >= parse_version(version_rule[1]) }
-        when :lte
+        when :lte, :le
           supported_versions += available_version_definitions.versions_array.select { |av| av <= parse_version(version_rule[1]) }
         else
           raise "Rule type #{version_rule[0]} not supported yet, sorry..."

--- a/lib/flappi/versions.rb
+++ b/lib/flappi/versions.rb
@@ -6,7 +6,7 @@ module Flappi
     attr_reader :versions_array
 
     delegate :to_json, to: :string_versions
-    delegate :size, :first, :last, :select, :each, :[], :to_a, to: :versions_array
+    delegate :size, :first, :last, :select, :each, :map, :[], :to_a, to: :versions_array
 
 
     def initialize(versions_array)

--- a/lib/flappi/versions.rb
+++ b/lib/flappi/versions.rb
@@ -22,6 +22,10 @@ module Flappi
       "[#{string_versions.join(', ')}]"
     end
 
+    def to_a
+      @versions_array
+    end
+
     def ==(other)
       versions_array == other.versions_array
     end

--- a/lib/flappi/versions.rb
+++ b/lib/flappi/versions.rb
@@ -6,7 +6,8 @@ module Flappi
     attr_reader :versions_array
 
     delegate :to_json, to: :string_versions
-    delegate :size, :first, :last, :select, to: :versions_array
+    delegate :size, :first, :last, :select, :each, :[], :to_a, to: :versions_array
+
 
     def initialize(versions_array)
       #        puts "Versions: #{versions_array}"
@@ -20,10 +21,6 @@ module Flappi
 
     def to_s
       "[#{string_versions.join(', ')}]"
-    end
-
-    def to_a
-      @versions_array
     end
 
     def ==(other)

--- a/lib/flappi/versions.rb
+++ b/lib/flappi/versions.rb
@@ -8,7 +8,6 @@ module Flappi
     delegate :to_json, to: :string_versions
     delegate :size, :first, :last, :select, :each, :map, :[], :to_a, to: :versions_array
 
-
     def initialize(versions_array)
       #        puts "Versions: #{versions_array}"
       @versions_array = versions_array

--- a/system/hooks/rubocop_pre_commit.rb
+++ b/system/hooks/rubocop_pre_commit.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'english'
+require 'rubocop'
+
+ADDED_OR_MODIFIED = /A|AM|^M/
+
+changed_files = `git status --porcelain`.split(/\n/)
+                                        .select { |file_name_with_status| file_name_with_status =~ ADDED_OR_MODIFIED }
+                                        .map { |file_name_with_status| file_name_with_status.split(' ')[1] }
+                                        .select { |file_name| ['.rb', '.rake'].include?(File.extname(file_name)) || file_name == 'Gemfile' }
+                                        .join(' ')
+
+system("bundle exec rubocop #{changed_files}") unless changed_files.empty?
+
+exit $CHILD_STATUS.to_s[-1].to_i

--- a/test/definition_locator_test.rb
+++ b/test/definition_locator_test.rb
@@ -7,10 +7,11 @@ class ::Flappi::DefinitionLocatorTest < MiniTest::Test
     should 'Locate a valid definition' do
       Flappi.configure do |conf|
         conf.definition_paths = {
-          'V2.0' => 'examples',
+          'v2.0' => 'examples',
+          'v3.0' => 'examples'
         }
       end
-      located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'V2.0')
+      located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'v2.0')
       assert_equal Examples::Exercise1, located_class
     end
 
@@ -34,13 +35,14 @@ class ::Flappi::DefinitionLocatorTest < MiniTest::Test
     should 'Raise an error when no valid definition' do
       Flappi.configure do |conf|
         conf.definition_paths = {
-          'V2.0' => 'examples',
+          'v2.0' => 'examples',
+          'v3.0' => 'examples'
         }
       end
 
       located_class = nil
       ex = assert_raises RuntimeError do
-        located_class = Flappi::DefinitionLocator.locate_class('DoesntExist', 'V2.0')
+        located_class = Flappi::DefinitionLocator.locate_class('DoesntExist', 'v2.0')
       end
 
       assert_equal 'Endpoint DoesntExist is not defined to Flappi: Could not load Examples::DoesntExist because uninitialized constant Examples::DoesntExist was raised', ex.message

--- a/test/definition_locator_test.rb
+++ b/test/definition_locator_test.rb
@@ -6,24 +6,27 @@ class ::Flappi::DefinitionLocatorTest < MiniTest::Test
   context 'locate_class' do
     should 'Locate a valid definition' do
       Flappi.configure do |conf|
-        conf.definition_paths = ['examples']
+        conf.definition_paths = {
+          'V2.0' => 'examples',
+        }
       end
-      located_class = Flappi::DefinitionLocator.locate_class('Exercise1')
+      located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'V2.0')
       assert_equal Examples::Exercise1, located_class
     end
 
     should 'Raise an error when no valid definition' do
       Flappi.configure do |conf|
-        conf.definition_paths = ['examples']
+        conf.definition_paths = {
+          'V2.0' => 'examples',
+        }
       end
 
       located_class = nil
       ex = assert_raises RuntimeError do
-        located_class = Flappi::DefinitionLocator.locate_class('DoesntExist')
+        located_class = Flappi::DefinitionLocator.locate_class('DoesntExist', 'V2.0')
       end
 
-      assert_equal 'Endpoint DoesntExist is not defined to Flappi: Could not load Examples::DoesntExist because uninitialized constant Examples::DoesntExist was raised',
-                   ex.message
+      assert_equal 'Endpoint DoesntExist is not defined to Flappi: Could not load Examples::DoesntExist because uninitialized constant Examples::DoesntExist was raised', ex.message
       refute located_class
     end
   end

--- a/test/definition_locator_test.rb
+++ b/test/definition_locator_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require_relative 'test_helper'
 
+require_relative 'test_helper'
 require_relative './examples2/exercise1'
 require_relative './examples2/exercise5'
 
@@ -12,14 +12,14 @@ class ::Flappi::DefinitionLocatorTest < MiniTest::Test
     end
 
     should 'Locate a valid definition by order in the definition_paths config' do
-      # eg. definition_paths = { 'v3.0': ['examples', 'examples2'] } – this test targets the first `examples` and ignores the second.
+      # eg. definition_paths = { 'v3.0': ['examples', 'examples2'] } - this test targets the first `examples` and ignores the second.
       located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'v3.0')
       assert_equal Examples::Exercise1, located_class
       assert_equal 'examples', located_class.definition_source
     end
 
     should 'Locate a valid version as a fallback by order in the definition_paths config' do
-      # eg. definition_paths = { 'v3.0': ['examples', 'examples2'] } – this test targets the `examples2` as it does not exist in `examples`.
+      # eg. definition_paths = { 'v3.0': ['examples', 'examples2'] } - this test targets the `examples2` as it does not exist in `examples`.
       located_class = Flappi::DefinitionLocator.locate_class('Exercise5', 'v3.0')
       assert_equal Examples2::Exercise5, located_class
       assert_equal 'examples2', located_class.definition_source

--- a/test/definition_locator_test.rb
+++ b/test/definition_locator_test.rb
@@ -14,6 +14,23 @@ class ::Flappi::DefinitionLocatorTest < MiniTest::Test
       assert_equal Examples::Exercise1, located_class
     end
 
+    should 'Raise an error with a missing version' do
+      Flappi.configure do |conf|
+        conf.definition_paths = {
+          'v2.0' => 'examples',
+          'v3.0' => 'examples'
+        }
+      end
+
+      located_class = nil
+      ex = assert_raises RuntimeError do
+        located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'v-bad-version')
+      end
+
+      assert_equal 'Unable to find a definition_path for v-bad-version.', ex.message
+      refute located_class
+    end
+
     should 'Raise an error when no valid definition' do
       Flappi.configure do |conf|
         conf.definition_paths = {

--- a/test/definition_locator_test.rb
+++ b/test/definition_locator_test.rb
@@ -1,12 +1,28 @@
 # frozen_string_literal: true
-
 require_relative 'test_helper'
+
+require_relative './examples2/exercise1'
+require_relative './examples2/exercise5'
 
 class ::Flappi::DefinitionLocatorTest < MiniTest::Test
   context 'locate_class' do
     should 'Locate a valid definition' do
       located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'v2.0')
       assert_equal Examples::Exercise1, located_class
+    end
+
+    should 'Locate a valid definition by order in the definition_paths config' do
+      # eg. definition_paths = { 'v3.0': ['examples', 'examples2'] } – this test targets the first `examples` and ignores the second.
+      located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'v3.0')
+      assert_equal Examples::Exercise1, located_class
+      assert_equal 'examples', located_class.definition_source
+    end
+
+    should 'Locate a valid version as a fallback by order in the definition_paths config' do
+      # eg. definition_paths = { 'v3.0': ['examples', 'examples2'] } – this test targets the `examples2` as it does not exist in `examples`.
+      located_class = Flappi::DefinitionLocator.locate_class('Exercise5', 'v3.0')
+      assert_equal Examples2::Exercise5, located_class
+      assert_equal 'examples2', located_class.definition_source
     end
 
     should 'Raise an error with a missing version' do

--- a/test/definition_locator_test.rb
+++ b/test/definition_locator_test.rb
@@ -5,24 +5,11 @@ require_relative 'test_helper'
 class ::Flappi::DefinitionLocatorTest < MiniTest::Test
   context 'locate_class' do
     should 'Locate a valid definition' do
-      Flappi.configure do |conf|
-        conf.definition_paths = {
-          'v2.0' => 'examples',
-          'v3.0' => 'examples'
-        }
-      end
       located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'v2.0')
       assert_equal Examples::Exercise1, located_class
     end
 
     should 'Raise an error with a missing version' do
-      Flappi.configure do |conf|
-        conf.definition_paths = {
-          'v2.0' => 'examples',
-          'v3.0' => 'examples'
-        }
-      end
-
       located_class = nil
       ex = assert_raises RuntimeError do
         located_class = Flappi::DefinitionLocator.locate_class('Exercise1', 'v-bad-version')
@@ -33,13 +20,6 @@ class ::Flappi::DefinitionLocatorTest < MiniTest::Test
     end
 
     should 'Raise an error when no valid definition' do
-      Flappi.configure do |conf|
-        conf.definition_paths = {
-          'v2.0' => 'examples',
-          'v3.0' => 'examples'
-        }
-      end
-
       located_class = nil
       ex = assert_raises RuntimeError do
         located_class = Flappi::DefinitionLocator.locate_class('DoesntExist', 'v2.0')

--- a/test/examples/empty_object.rb
+++ b/test/examples/empty_object.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Examples
+  module EmptyObject
+    include Flappi::Definition
+
+    def endpoint; end
+
+    def respond
+      build do
+        # this will return an empty object, not :no_content
+      end
+    end
+  end
+end

--- a/test/examples/exercise1.rb
+++ b/test/examples/exercise1.rb
@@ -4,6 +4,12 @@ module Examples
   module Exercise1
     include Flappi::Definition
 
+    # Strictly to test which folder this came from.  This would not be in a real definition folder.
+    # see test/definition_locator_test.rb
+    def self.definition_source
+      'examples'
+    end
+
     def endpoint
       group 'Test_Exercise'
       http_method 'GET'

--- a/test/examples/exercise2_versioned.rb
+++ b/test/examples/exercise2_versioned.rb
@@ -10,7 +10,7 @@ module Examples
       path '/examples/exercise2'
       title 'Exercise API 2'
       description 'Exercise definition DSL #2 with versioning'
-      version equals: 'V2.*-mobile'
+      version equals: 'v2.*-mobile'
 
       param :required, optional: false, type: Float do |v|
         v >= 0 && v < 10 ? nil : 'Parameter v outside range 0..10'
@@ -21,8 +21,8 @@ module Examples
       build type: Examples::ExerciseModel do
         field :all
 
-        field :v2_0_only, version: { equals: 'V2.0.*-*' }
-        field :v2_1_only, version: { equals: 'V2.1.*-*' }
+        field :v2_0_only, version: { equals: 'v2.0.*-*' }
+        field :v2_1_only, version: { equals: 'v2.1.*-*' }
       end
     end
   end

--- a/test/examples/no_content.rb
+++ b/test/examples/no_content.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/RedundantReturn, Lint/MissingCopEnableDirective
+
+module Examples
+  module NoContent
+    include Flappi::Definition
+
+    def endpoint; end
+
+    def respond
+      return # nothing; this will 204
+    end
+  end
+end

--- a/test/examples/no_content_return.rb
+++ b/test/examples/no_content_return.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Examples
+  module NoContentReturn
+    include Flappi::Definition
+
+    def endpoint
+      query do
+        return_no_content
+      end
+    end
+
+    def respond
+      build do
+      end
+    end
+  end
+end

--- a/test/examples/v2_version_plan.rb
+++ b/test/examples/v2_version_plan.rb
@@ -13,6 +13,8 @@ module Examples
       flavour :flat
     end
 
+    version 'v3.0.0'
+
     flavour ''
 
     # 2.0.0 or 2.1.0 can take the mobile flavour, which is for internal use only

--- a/test/examples/v2_version_plan.rb
+++ b/test/examples/v2_version_plan.rb
@@ -6,9 +6,9 @@ module Examples
 
     # Version numbers are of the form [text][N][,]+[-flavour]
 
-    version 'V2.0.0'
+    version 'v2.0.0'
 
-    version 'V2.1.0' do
+    version 'v2.1.0' do
       flavour :ember
       flavour :flat
     end

--- a/test/examples/version_plan.rb
+++ b/test/examples/version_plan.rb
@@ -6,18 +6,18 @@ module Examples
 
     # Version numbers are of the form [text][N][,]+[-flavour]
 
-    version 'v2.0.0'
+    version 'v2.0.0' do
+      flavour :mobile
+    end
 
     version 'v2.1.0' do
       flavour :ember
       flavour :flat
+      flavour :mobile
     end
 
     version 'v3.0.0'
 
     flavour ''
-
-    # 2.0.0 or 2.1.0 can take the mobile flavour, which is for internal use only
-    flavour :mobile
   end
 end

--- a/test/examples/version_plan.rb
+++ b/test/examples/version_plan.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Examples
-  class V2VersionPlan
+  class VersionPlan
     extend Flappi::VersionPlan
 
     # Version numbers are of the form [text][N][,]+[-flavour]

--- a/test/examples2/exercise1.rb
+++ b/test/examples2/exercise1.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Examples2
+  module Exercise1
+    include Flappi::Definition
+
+    # Strictly to test which folder this came from.  This would not be in a real definition folder.
+    # see test/definition_locator_test.rb
+    def self.definition_source
+      'examples2'
+    end
+  end
+end

--- a/test/examples2/exercise5.rb
+++ b/test/examples2/exercise5.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Examples2
+  module Exercise5
+    include Flappi::Definition
+
+    # Strictly to test which folder this came from.  This would not be in a real definition folder.
+    # see test/definition_locator_test.rb
+    def self.definition_source
+      'examples2'
+    end
+  end
+end

--- a/test/integration/empty_object_test.rb
+++ b/test/integration/empty_object_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'pp'
+require_relative '../test_helper'
+require_relative '../examples/empty_object'
+
+module Examples
+  class EmptyObjectController < ExampleController
+  end
+end
+
+module Integration
+  class EmptyObjectTest < MiniTest::Test
+    context 'Response to EmptyObject' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'respond with an empty object' do
+        controller = Examples::EmptyObjectController.new
+        response = controller.show
+
+        refute_equal(:no_content, controller.last_head_params)
+        assert_equal({}, response)
+      end
+    end
+  end
+end

--- a/test/integration/exercise1_response_test.rb
+++ b/test/integration/exercise1_response_test.rb
@@ -7,28 +7,13 @@ require 'pp'
 require_relative '../examples/exercise1'
 
 module Examples
-  class Exercise1Controller
-    attr_accessor :params
-    attr_accessor :last_render_params
-
+  class Exercise1Controller < ExampleController
     def initialize
       self.params = { extra: 50 }
     end
 
-    def show
-      Flappi.build_and_respond(self)
-    end
-
     def request
       OpenStruct.new(query_parameters: params, url: 'http://test.api/exercise1')
-    end
-
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
     end
   end
 end

--- a/test/integration/exercise2_doco_test.rb
+++ b/test/integration/exercise2_doco_test.rb
@@ -4,7 +4,7 @@ require_relative '../test_helper'
 
 require 'pp'
 
-require_relative '../examples/v2_version_plan'
+require_relative '../examples/version_plan'
 require_relative '../examples/exercise_model'
 require_relative '../examples/exercise2_versioned'
 
@@ -13,7 +13,7 @@ module Integration
     context 'Documentation of Exercise2' do
       setup do
         Flappi.configure do |conf|
-          conf.version_plan = Examples::V2VersionPlan
+          conf.version_plan = Examples::VersionPlan
         end
       end
 

--- a/test/integration/exercise2_response_test.rb
+++ b/test/integration/exercise2_response_test.rb
@@ -86,8 +86,8 @@ module Integration
         response = controller.show
 
         refute response
-        assert_equal({ json: '{"error":"Version V1.9 not supported by endpoint"}',
-                       plain: 'Version V1.9 not supported by endpoint', status: :not_acceptable },
+        assert_equal({ json: '{"error":"Version v1.9 not supported by endpoint"}',
+                       plain: 'Version v1.9 not supported by endpoint', status: :not_acceptable },
                      controller.last_render_params)
       end
     end

--- a/test/integration/exercise2_response_test.rb
+++ b/test/integration/exercise2_response_test.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 require 'pp'
 
 require_relative '../examples/exercise2_versioned'
-require_relative '../examples/v2_version_plan'
+require_relative '../examples/version_plan'
 require_relative '../examples/exercise_model'
 
 module Examples
@@ -36,7 +36,7 @@ module Integration
     context 'Response to Exercise2' do
       setup do
         Flappi.configure do |conf|
-          conf.version_plan = Examples::V2VersionPlan
+          conf.version_plan = Examples::VersionPlan
         end
       end
 

--- a/test/integration/exercise2_response_test.rb
+++ b/test/integration/exercise2_response_test.rb
@@ -42,7 +42,7 @@ module Integration
 
       should 'respond with version 2.1 result' do
         controller = Examples::Exercise2VersionedController.new
-        controller.params = { required: 2.718, version: 'V2.1.0-mobile' }
+        controller.params = { required: 2.718, version: 'v2.1.0-mobile' }
         response = controller.show
 
         assert_equal({ 'all' => 'all_versions', 'v2_1_only' => 2.1 },
@@ -51,7 +51,7 @@ module Integration
 
       should 'respond with version 2.0 result' do
         controller = Examples::Exercise2VersionedController.new
-        controller.params = { required: 3.142, version: 'V2.0-mobile' }
+        controller.params = { required: 3.142, version: 'v2.0-mobile' }
         response = controller.show
 
         assert_equal({ 'all' => 'all_versions', 'v2_0_only' => 2.0 },
@@ -60,7 +60,7 @@ module Integration
 
       should 'fail for missing required parameter' do
         controller = Examples::Exercise2VersionedController.new
-        controller.params = { version: 'V2.0-mobile' }
+        controller.params = { version: 'v2.0-mobile' }
         response = controller.show
 
         refute response
@@ -71,7 +71,7 @@ module Integration
 
       should 'fail when parameter fails validation' do
         controller = Examples::Exercise2VersionedController.new
-        controller.params = { required: 123.4, version: 'V2.0-mobile' }
+        controller.params = { required: 123.4, version: 'v2.0-mobile' }
         response = controller.show
 
         refute response
@@ -82,7 +82,7 @@ module Integration
 
       should 'fail for unsupported version' do
         controller = Examples::Exercise2VersionedController.new
-        controller.params = { required: 1.414, version: 'V1.9' }
+        controller.params = { required: 1.414, version: 'v1.9' }
         response = controller.show
 
         refute response

--- a/test/integration/exercise2_response_test.rb
+++ b/test/integration/exercise2_response_test.rb
@@ -9,25 +9,7 @@ require_relative '../examples/version_plan'
 require_relative '../examples/exercise_model'
 
 module Examples
-  class Exercise2VersionedController
-    attr_accessor :params
-    attr_accessor :last_render_params
-
-    def show
-      Flappi.build_and_respond(self)
-    end
-
-    def request
-      OpenStruct.new(query_parameters: params)
-    end
-
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
-    end
+  class Exercise2VersionedController < ExampleController
   end
 end
 

--- a/test/integration/exercise3_response_test.rb
+++ b/test/integration/exercise3_response_test.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 require 'pp'
 
 require_relative '../examples/exercise3_my_method'
-require_relative '../examples/v2_version_plan'
+require_relative '../examples/version_plan'
 require_relative '../examples/exercise_model'
 
 module Examples

--- a/test/integration/exercise3_response_test.rb
+++ b/test/integration/exercise3_response_test.rb
@@ -9,24 +9,13 @@ require_relative '../examples/version_plan'
 require_relative '../examples/exercise_model'
 
 module Examples
-  class Exercise3Controller
-    attr_accessor :params
-    attr_accessor :last_render_params
-
+  class Exercise3Controller < ExampleController
     def my_method
       Flappi.build_and_respond(self, :my_method)
     end
 
     def request
       OpenStruct.new(query_parameters: params, raw_post: 'This is raw post data')
-    end
-
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
     end
   end
 end

--- a/test/integration/exercise3_response_test.rb
+++ b/test/integration/exercise3_response_test.rb
@@ -36,7 +36,7 @@ module Integration
     context 'Response to Exercise3' do
       should 'respond with ok to posted data' do
         controller = Examples::Exercise3Controller.new
-        controller.params = { required: 2.718, version: 'V2.1.0-mobile' }
+        controller.params = { required: 2.718, version: 'v2.1.0-mobile' }
         response = controller.my_method
 
         assert_equal({ 'ok' => true },

--- a/test/integration/exercise4_response_test.rb
+++ b/test/integration/exercise4_response_test.rb
@@ -45,8 +45,7 @@ module Integration
       should 'respond with a composed block' do
         response = Examples::Exercise4Controller.new.show
 
-        assert_equal({ 'a_not' => 100, 'b_how' => 100 },
-                     response)
+        assert_equal({ 'a_not' => 100, 'b_how' => 100 }, response)
       end
     end
   end

--- a/test/integration/exercise4_response_test.rb
+++ b/test/integration/exercise4_response_test.rb
@@ -7,29 +7,7 @@ require 'pp'
 require_relative '../examples/exercise4'
 
 module Examples
-  class Exercise4Controller
-    attr_accessor :params
-    attr_accessor :last_render_params
-
-    def initialize
-      self.params = {}
-    end
-
-    def show
-      Flappi.build_and_respond(self)
-    end
-
-    def request
-      OpenStruct.new(query_parameters: params)
-    end
-
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
-    end
+  class Exercise4Controller < ExampleController
   end
 end
 

--- a/test/integration/no_content_return_test.rb
+++ b/test/integration/no_content_return_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'pp'
+require_relative '../test_helper'
+require_relative '../examples/no_content_return'
+
+module Examples
+  class NoContentReturnController < ExampleController
+  end
+end
+
+module Integration
+  class NoContentReturnTest < MiniTest::Test
+    context 'Response to NoContentReturn' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'respond :no_content the stubbed controller head method when content is falsey' do
+        controller = Examples::NoContentReturnController.new
+        controller.show # doesn't return anything useful; not an actual response
+
+        assert_equal(:no_content, controller.last_head_params)
+      end
+    end
+  end
+end

--- a/test/integration/no_content_test.rb
+++ b/test/integration/no_content_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'pp'
+require_relative '../test_helper'
+require_relative '../examples/no_content'
+
+module Examples
+  class NoContentController < ExampleController
+  end
+end
+
+module Integration
+  class NoContentTest < MiniTest::Test
+    context 'Response to NoContent' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'respond :no_content the stubbed controller head method when content is falsey' do
+        controller = Examples::NoContentController.new
+        controller.show # doesn't return anything useful; not an actual response
+
+        assert_equal(:no_content, controller.last_head_params)
+      end
+    end
+  end
+end

--- a/test/response_builder_test.rb
+++ b/test/response_builder_test.rb
@@ -3,7 +3,7 @@
 require_relative 'test_helper'
 require 'pp'
 
-require_relative 'examples/v2_version_plan'
+require_relative 'examples/version_plan'
 
 class TestDef
   include ::Flappi::Definition
@@ -22,8 +22,8 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
       @response_builder.source_definition = TestDef.new
       @response_builder.controller_params = { portfolio_id: '123', extra: '456', auth_token: 'xyzzy', controller: 'test', action: 'test' }
       @response_builder.controller_query_parameters = {}
-      @response_builder.version_plan = Examples::V2VersionPlan
-      @response_builder.requested_version = Examples::V2VersionPlan.parse_version('v2.1')
+      @response_builder.version_plan = Examples::VersionPlan
+      @response_builder.requested_version = Examples::VersionPlan.parse_version('v2.1')
 
       @test_proc = ->(_cp) { { a: 1, b: 200 } }
     end

--- a/test/response_builder_test.rb
+++ b/test/response_builder_test.rb
@@ -23,7 +23,7 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
       @response_builder.controller_params = { portfolio_id: '123', extra: '456', auth_token: 'xyzzy', controller: 'test', action: 'test' }
       @response_builder.controller_query_parameters = {}
       @response_builder.version_plan = Examples::V2VersionPlan
-      @response_builder.requested_version = Examples::V2VersionPlan.parse_version('V2.1')
+      @response_builder.requested_version = Examples::V2VersionPlan.parse_version('v2.1')
 
       @test_proc = ->(_cp) { { a: 1, b: 200 } }
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ end
 
 require 'maxitest/autorun'
 require 'shoulda'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require 'flappi'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ Flappi.configure do |conf|
     'v2.1.0-mobile' => 'examples',
     'v3.0' => ['examples', 'examples2'],
     'v1.9' => 'examples',
-    'default' => 'examples' # empty, because half the tests don't have versions...?
+    'default' => 'examples' # when you pass no version, it goes to default
   }
   conf.version_plan = nil
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ Flappi.configure do |conf|
     'v2.0' => 'examples',
     'v2.0-mobile' => 'examples',
     'v2.1.0-mobile' => 'examples',
-    'v3.0' => ['examples', 'examples'],
+    'v3.0' => ['examples', 'examples2'],
     'v1.9' => 'examples',
     'default' => 'examples' # empty, because half the tests don't have versions...?
   }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,3 +43,36 @@ class JsonFormatter
     yield
   end
 end
+
+module Examples
+  class ExampleController
+    # this is a stub of a controller, think ActionController
+    attr_accessor :params
+    attr_accessor :last_render_params
+    attr_accessor :last_head_params
+
+    def initialize
+      self.params = {}
+    end
+
+    def show
+      Flappi.build_and_respond(self)
+    end
+
+    def request
+      OpenStruct.new(query_parameters: params)
+    end
+
+    def respond_to
+      yield JsonFormatter.new
+    end
+
+    def render(params)
+      self.last_render_params = params
+    end
+
+    def head(params)
+      self.last_head_params = params
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ Flappi.configure do |conf|
     'v2.0' => 'examples',
     'v2.0-mobile' => 'examples',
     'v2.1.0-mobile' => 'examples',
+    'v3.0' => ['examples', 'examples'],
     'v1.9' => 'examples',
     'default' => 'examples' # empty, because half the tests don't have versions...?
   }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ Flappi.configure do |conf|
     'v2.0-mobile' => 'examples',
     'v2.1.0-mobile' => 'examples',
     'v1.9' => 'examples',
+    'default' => 'examples' # empty, because half the tests don't have versions...?
   }
   conf.version_plan = nil
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,12 @@ require 'mocha/minitest'
 require 'flappi'
 
 Flappi.configure do |conf|
-  conf.definition_paths = 'examples'
+  conf.definition_paths = {
+    'V2.0' => 'examples',
+    'V2.0-mobile' => 'examples',
+    'V2.1.0-mobile' => 'examples',
+    'V1.9' => 'examples',
+  }
   conf.version_plan = nil
 
   if ENV['TEST_LOGGING']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,10 +13,10 @@ require 'flappi'
 
 Flappi.configure do |conf|
   conf.definition_paths = {
-    'V2.0' => 'examples',
-    'V2.0-mobile' => 'examples',
-    'V2.1.0-mobile' => 'examples',
-    'V1.9' => 'examples',
+    'v2.0' => 'examples',
+    'v2.0-mobile' => 'examples',
+    'v2.1.0-mobile' => 'examples',
+    'v1.9' => 'examples',
   }
   conf.version_plan = nil
 

--- a/test/version_plan_test.rb
+++ b/test/version_plan_test.rb
@@ -8,8 +8,10 @@ class Flappi::VersionPlanTest < MiniTest::Test
   context 'using v2_version_plan' do
     should 'return available_version_definitions' do
       expect_versions = Examples::V2VersionPlan.parse_versions('v2.0;v2.0-mobile;v2.1;v2.1-ember;v2.1-flat;v2.1-mobile')
-      assert_equal expect_versions,
-                   Examples::V2VersionPlan.available_version_definitions
+
+      expect_versions.to_a.each do |version|
+        assert_includes Examples::V2VersionPlan.available_version_definitions, version
+      end
     end
 
     should 'parse and stringise a version' do

--- a/test/version_plan_test.rb
+++ b/test/version_plan_test.rb
@@ -2,125 +2,125 @@
 
 require_relative 'test_helper'
 
-require_relative 'examples/v2_version_plan'
+require_relative 'examples/version_plan'
 
 class Flappi::VersionPlanTest < MiniTest::Test
-  context 'using v2_version_plan' do
+  context 'using version_plan' do
     should 'return available_version_definitions' do
-      expect_versions = Examples::V2VersionPlan.parse_versions('v2.0;v2.0-mobile;v2.1;v2.1-ember;v2.1-flat;v2.1-mobile')
+      expect_versions = Examples::VersionPlan.parse_versions('v2.0;v2.0-mobile;v2.1;v2.1-ember;v2.1-flat;v2.1-mobile')
 
       expect_versions.to_a.each do |version|
-        assert_includes Examples::V2VersionPlan.available_version_definitions, version
+        assert_includes Examples::VersionPlan.available_version_definitions, version
       end
     end
 
     should 'parse and stringise a version' do
-      ver = Examples::V2VersionPlan.parse_version('v2.1.2')
+      ver = Examples::VersionPlan.parse_version('v2.1.2')
       assert_equal '2.1.2', ver.to_s
 
-      ver = Examples::V2VersionPlan.parse_version('v2.1.2-flat')
+      ver = Examples::VersionPlan.parse_version('v2.1.2-flat')
       assert_equal '2.1.2-flat', ver.to_s
     end
 
     should 'parse versions with wildcards' do
-      ver = Examples::V2VersionPlan.parse_version('v2.*.2')
+      ver = Examples::VersionPlan.parse_version('v2.*.2')
       assert_equal '2.*.2', ver.to_s
 
-      ver = Examples::V2VersionPlan.parse_version('v2.1.2-*')
+      ver = Examples::VersionPlan.parse_version('v2.1.2-*')
       assert_equal '2.1.2-*', ver.to_s
     end
 
     should 'parse and stringise a minor version' do
-      ver = Examples::V2VersionPlan.parse_version('m2.1')
+      ver = Examples::VersionPlan.parse_version('m2.1')
       assert_equal '2.1', ver.to_s
 
-      ver = Examples::V2VersionPlan.parse_version('m2.1-ember')
+      ver = Examples::VersionPlan.parse_version('m2.1-ember')
       assert_equal '2.1-ember', ver.to_s
     end
 
     context 'version equality' do
       should 'compare same without wildcard' do
-        v1 = Examples::V2VersionPlan.parse_version('m2.1-ember')
-        v2 = Examples::V2VersionPlan.parse_version('m2.1-ember')
+        v1 = Examples::VersionPlan.parse_version('m2.1-ember')
+        v2 = Examples::VersionPlan.parse_version('m2.1-ember')
         assert v1 == v2
       end
 
       should 'compare different without wildcard' do
-        v1 = Examples::V2VersionPlan.parse_version('m2.1-ember')
-        v2 = Examples::V2VersionPlan.parse_version('m2.2-ember')
+        v1 = Examples::VersionPlan.parse_version('m2.1-ember')
+        v2 = Examples::VersionPlan.parse_version('m2.2-ember')
         refute v1 == v2
       end
 
       should 'compare same with wildcard' do
-        v1 = Examples::V2VersionPlan.parse_version('m2.1-ember')
-        v2 = Examples::V2VersionPlan.parse_version('m2.1-*')
+        v1 = Examples::VersionPlan.parse_version('m2.1-ember')
+        v2 = Examples::VersionPlan.parse_version('m2.1-*')
         assert v1 == v2
       end
 
       should 'compare different with wildcard' do
-        v1 = Examples::V2VersionPlan.parse_version('m2.1-ember')
-        v2 = Examples::V2VersionPlan.parse_version('m2.*-flat')
+        v1 = Examples::VersionPlan.parse_version('m2.1-ember')
+        v2 = Examples::VersionPlan.parse_version('m2.*-flat')
         refute v1 == v2
       end
     end
 
     context 'version list include' do
       should 'detect included' do
-        ver_list = Examples::V2VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2')
-        assert ver_list.include? Examples::V2VersionPlan.parse_version('v2.1-flat')
+        ver_list = Examples::VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2')
+        assert ver_list.include? Examples::VersionPlan.parse_version('v2.1-flat')
       end
 
       should 'detect included in defaults' do
-        default_list = Examples::V2VersionPlan.parse_versions('v2.1; v2.2')
-        ver_list = Examples::V2VersionPlan.parse_versions('default; v2.1-flat', default_list)
-        assert ver_list.include? Examples::V2VersionPlan.parse_version('v2.2')
+        default_list = Examples::VersionPlan.parse_versions('v2.1; v2.2')
+        ver_list = Examples::VersionPlan.parse_versions('default; v2.1-flat', default_list)
+        assert ver_list.include? Examples::VersionPlan.parse_version('v2.2')
       end
 
       should 'detect included in stringy defaults' do
-        ver_list = Examples::V2VersionPlan.parse_versions('default; v2.1-flat', 'v2.1; v2.2')
-        assert ver_list.include? Examples::V2VersionPlan.parse_version('v2.2')
+        ver_list = Examples::VersionPlan.parse_versions('default; v2.1-flat', 'v2.1; v2.2')
+        assert ver_list.include? Examples::VersionPlan.parse_version('v2.2')
       end
 
       should 'not detect not included' do
-        ver_list = Examples::V2VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2')
-        refute ver_list.include? Examples::V2VersionPlan.parse_version('v2.3')
+        ver_list = Examples::VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2')
+        refute ver_list.include? Examples::VersionPlan.parse_version('v2.3')
       end
     end
 
     context 'parse_versions' do
       should 'parse and normalise' do
-        ver_list = Examples::V2VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2', [], true)
+        ver_list = Examples::VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2', [], true)
         assert_equal '[2.1.0, 2.1.0-flat, 2.2.0]', ver_list.to_s
       end
 
       should 'parse and not normalise' do
-        ver_list = Examples::V2VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2', [], false)
+        ver_list = Examples::VersionPlan.parse_versions('v2.1; v2.1-flat;v2.2', [], false)
         assert_equal '[2.1, 2.1-flat, 2.2]', ver_list.to_s
       end
     end
 
     context 'minimum_version' do
       should 'return the lowest version definition without a flavour or with the lowest value in sort if all have flavours' do
-        assert_equal '2.0.0', Examples::V2VersionPlan.minimum_version.to_s
+        assert_equal '2.0.0', Examples::VersionPlan.minimum_version.to_s
       end
     end
 
     context 'parse version rules' do
       should 'work without wildcard' do
-        matched = Examples::V2VersionPlan.expand_version_rule :equals, 'v2.1-mobile'
+        matched = Examples::VersionPlan.expand_version_rule :equals, 'v2.1-mobile'
         assert_equal 1, matched.size
         assert_equal '2.1.0-mobile', matched.first.to_s
       end
 
       should 'work with wildcard' do
-        matched = Examples::V2VersionPlan.expand_version_rule :equals, 'v2.*.*-mobile'
+        matched = Examples::VersionPlan.expand_version_rule :equals, 'v2.*.*-mobile'
         assert_equal 2, matched.size
         assert_equal '2.0.0-mobile', matched.first.to_s
         assert_equal '2.1.0-mobile', matched.last.to_s
       end
 
       should 'fail for unsupported rule type' do
-        exception = assert_raises(RuntimeError) { Examples::V2VersionPlan.expand_version_rule :greater_than, 'v2.*.*-mobile' }
+        exception = assert_raises(RuntimeError) { Examples::VersionPlan.expand_version_rule :greater_than, 'v2.*.*-mobile' }
         assert_equal 'Rule type greater_than not supported yet, sorry...', exception.message
       end
     end

--- a/test/version_plan_test.rb
+++ b/test/version_plan_test.rb
@@ -9,7 +9,7 @@ class Flappi::VersionPlanTest < MiniTest::Test
     should 'return available_version_definitions' do
       expect_versions = Examples::VersionPlan.parse_versions('v2.0;v2.0-mobile;v2.1;v2.1-ember;v2.1-flat;v2.1-mobile')
 
-      expect_versions.to_a.each do |version|
+      expect_versions.each do |version|
         assert_includes Examples::VersionPlan.available_version_definitions, version
       end
     end

--- a/test/version_plan_test.rb
+++ b/test/version_plan_test.rb
@@ -137,7 +137,7 @@ class Flappi::VersionPlanTest < MiniTest::Test
         assert_equal matched.map(&:to_s), ['2.1.0', '3.0.0']
       end
 
-      should 'work with ge' do
+      should 'work with gte' do
         matched = Examples::VersionPlan.expand_version_rule gte: 'v2.0-'
 
         assert_equal 3, matched.size

--- a/test/version_plan_test.rb
+++ b/test/version_plan_test.rb
@@ -107,56 +107,49 @@ class Flappi::VersionPlanTest < MiniTest::Test
 
     context 'parse version rules' do
       should 'work without wildcard' do
-        matched = Examples::VersionPlan.expand_version_rule :equals, 'v2.1-mobile'
+        matched = Examples::VersionPlan.expand_version_rule equals: 'v2.1-mobile'
         assert_equal 1, matched.size
         assert_equal '2.1.0-mobile', matched.first.to_s
       end
 
       should 'work with wildcard' do
-        matched = Examples::VersionPlan.expand_version_rule :equals, 'v2.*.*-mobile'
+        matched = Examples::VersionPlan.expand_version_rule equals: 'v2.*.*-mobile'
         assert_equal 2, matched.size
         assert_equal '2.0.0-mobile', matched.first.to_s
         assert_equal '2.1.0-mobile', matched.last.to_s
       end
 
       should 'work with ne' do
-        matched = Examples::VersionPlan.expand_version_rule :ne, 'v2.1-mobile'
-        assert_equal 5, matched.size
-        assert_equal '2.0.0', matched[0].to_s
-        assert_equal '2.0.0-mobile', matched[1].to_s
-        assert_equal '2.1.0', matched[2].to_s
-        assert_equal '2.1.0-ember', matched[3].to_s
-        assert_equal '2.1.0-flat', matched[4].to_s
+        matched = Examples::VersionPlan.expand_version_rule ne: 'v2.1-mobile'
+        assert_equal 6, matched.size
+        assert_equal matched.map(&:to_s), ['2.0.0', '2.0.0-mobile', '2.1.0', '2.1.0-ember', '2.1.0-flat', '3.0.0']
       end
 
       should 'work with multiple rules ored together' do
-        matched = Examples::VersionPlan.expand_version_rule :equals, 'v2.0-', :ge, 'v2.1-*'
-        assert_equal 5, matched.size
-        assert_equal '2.0.0', matched[0].to_s
-        assert_equal '2.1.0', matched[1].to_s
-        assert_equal '2.1.0-ember', matched[2].to_s
-        assert_equal '2.1.0-flat', matched[3].to_s
-        assert_equal '2.1.0-mobile', matched[4].to_s
+        matched = Examples::VersionPlan.expand_version_rule equals: 'v2.0-', ge: 'v2.1-*'
+        assert_equal 6, matched.size
+        assert_equal matched.map(&:to_s), ['2.0.0', '2.1.0', '2.1.0-ember', '2.1.0-flat', '2.1.0-mobile', '3.0.0']
       end
 
       should 'work with after' do
-        matched = Examples::VersionPlan.expand_version_rule :after, 'v2.0-'
-        assert_equal 1, matched.size
-        assert_equal '2.1.0', matched.last.to_s
+        matched = Examples::VersionPlan.expand_version_rule after: 'v2.0-'
+
+        assert_equal 2, matched.size
+        assert_equal matched.map(&:to_s), ['2.1.0', '3.0.0']
       end
 
       should 'work with ge' do
-        matched = Examples::VersionPlan.expand_version_rule :ge, 'v2.0-'
-        assert_equal 2, matched.size
-        assert_equal '2.0.0', matched[0].to_s
-        assert_equal '2.1.0', matched[1].to_s
+        matched = Examples::VersionPlan.expand_version_rule ge: 'v2.0-'
+
+        assert_equal 3, matched.size
+        assert_equal matched.map(&:to_s), ['2.0.0', '2.1.0', '3.0.0']
       end
 
       should 'work with before' do
-        matched = Examples::VersionPlan.expand_version_rule :before, 'v2.1-*'
+        matched = Examples::VersionPlan.expand_version_rule before: 'v2.1-*'
+
         assert_equal 2, matched.size
-        assert_equal '2.0.0', matched.first.to_s
-        assert_equal '2.0.0-mobile', matched.last.to_s
+        assert_equal matched.map(&:to_s), ['2.0.0', '2.0.0-mobile']
       end
 
       should 'fail for unsupported rule type' do

--- a/test/version_plan_test.rb
+++ b/test/version_plan_test.rb
@@ -109,14 +109,13 @@ class Flappi::VersionPlanTest < MiniTest::Test
       should 'work without wildcard' do
         matched = Examples::VersionPlan.expand_version_rule equals: 'v2.1-mobile'
         assert_equal 1, matched.size
-        assert_equal '2.1.0-mobile', matched.first.to_s
+        assert_equal matched.map(&:to_s), ['2.1.0-mobile']
       end
 
       should 'work with wildcard' do
         matched = Examples::VersionPlan.expand_version_rule equals: 'v2.*.*-mobile'
         assert_equal 2, matched.size
-        assert_equal '2.0.0-mobile', matched.first.to_s
-        assert_equal '2.1.0-mobile', matched.last.to_s
+        assert_equal matched.map(&:to_s), ['2.0.0-mobile', '2.1.0-mobile']
       end
 
       should 'work with ne' do
@@ -126,7 +125,7 @@ class Flappi::VersionPlanTest < MiniTest::Test
       end
 
       should 'work with multiple rules ored together' do
-        matched = Examples::VersionPlan.expand_version_rule equals: 'v2.0-', ge: 'v2.1-*'
+        matched = Examples::VersionPlan.expand_version_rule equals: 'v2.0-', gte: 'v2.1-*'
         assert_equal 6, matched.size
         assert_equal matched.map(&:to_s), ['2.0.0', '2.1.0', '2.1.0-ember', '2.1.0-flat', '2.1.0-mobile', '3.0.0']
       end
@@ -139,7 +138,7 @@ class Flappi::VersionPlanTest < MiniTest::Test
       end
 
       should 'work with ge' do
-        matched = Examples::VersionPlan.expand_version_rule ge: 'v2.0-'
+        matched = Examples::VersionPlan.expand_version_rule gte: 'v2.0-'
 
         assert_equal 3, matched.size
         assert_equal matched.map(&:to_s), ['2.0.0', '2.1.0', '3.0.0']

--- a/test/version_plan_test.rb
+++ b/test/version_plan_test.rb
@@ -119,6 +119,46 @@ class Flappi::VersionPlanTest < MiniTest::Test
         assert_equal '2.1.0-mobile', matched.last.to_s
       end
 
+      should 'work with ne' do
+        matched = Examples::VersionPlan.expand_version_rule :ne, 'v2.1-mobile'
+        assert_equal 5, matched.size
+        assert_equal '2.0.0', matched[0].to_s
+        assert_equal '2.0.0-mobile', matched[1].to_s
+        assert_equal '2.1.0', matched[2].to_s
+        assert_equal '2.1.0-ember', matched[3].to_s
+        assert_equal '2.1.0-flat', matched[4].to_s
+      end
+
+      should 'work with multiple rules ored together' do
+        matched = Examples::VersionPlan.expand_version_rule :equals, 'v2.0-', :ge, 'v2.1-*'
+        assert_equal 5, matched.size
+        assert_equal '2.0.0', matched[0].to_s
+        assert_equal '2.1.0', matched[1].to_s
+        assert_equal '2.1.0-ember', matched[2].to_s
+        assert_equal '2.1.0-flat', matched[3].to_s
+        assert_equal '2.1.0-mobile', matched[4].to_s
+      end
+
+      should 'work with after' do
+        matched = Examples::VersionPlan.expand_version_rule :after, 'v2.0-'
+        assert_equal 1, matched.size
+        assert_equal '2.1.0', matched.last.to_s
+      end
+
+      should 'work with ge' do
+        matched = Examples::VersionPlan.expand_version_rule :ge, 'v2.0-'
+        assert_equal 2, matched.size
+        assert_equal '2.0.0', matched[0].to_s
+        assert_equal '2.1.0', matched[1].to_s
+      end
+
+      should 'work with before' do
+        matched = Examples::VersionPlan.expand_version_rule :before, 'v2.1-*'
+        assert_equal 2, matched.size
+        assert_equal '2.0.0', matched.first.to_s
+        assert_equal '2.0.0-mobile', matched.last.to_s
+      end
+
       should 'fail for unsupported rule type' do
         exception = assert_raises(RuntimeError) { Examples::VersionPlan.expand_version_rule :greater_than, 'v2.*.*-mobile' }
         assert_equal 'Rule type greater_than not supported yet, sorry...', exception.message

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+require_relative 'examples/version_plan'
+
+class Flappi::VersionTest < MiniTest::Test
+  context 'initialize' do
+    should 'set flavour to :_blank when nil' do
+      v = Flappi::Version.new([1, 0], nil, nil)
+      assert_equal :_blank, v.flavour
+    end
+
+    should 'set flavour to a symbol' do
+      v = Flappi::Version.new([1, 0], 'mobile', nil)
+      assert_equal :mobile, v.flavour
+    end
+  end
+
+  context 'normalise with example version plan' do
+    should 'return a matching value when same number of components' do
+      v = Flappi::Version.new([2, 0, 0], nil, Examples::VersionPlan)
+      assert_equal v, v.normalise
+    end
+
+    should 'normalize to a defined version' do
+      v = Flappi::Version.new([2], nil, Examples::VersionPlan)
+      assert_equal '2.0.0', v.normalise.to_s
+    end
+  end
+
+  context 'to_s' do
+    should 'return a version with flavour' do
+      v = Flappi::Version.new([2, 0], :mobile, Examples::VersionPlan)
+      assert_equal '2.0-mobile', v.to_s
+    end
+  end
+
+  context 'equal with ==' do
+    should 'return true when exactly same' do
+      va = Flappi::Version.new([1, 0], nil, nil)
+      vb = Flappi::Version.new([1, 0], nil, nil)
+      assert va == vb
+    end
+
+    should 'return false when not same' do
+      v1_0 = Flappi::Version.new([1, 0], nil, nil)
+      v1_1 = Flappi::Version.new([1, 1], nil, nil)
+      refute v1_0 == v1_1
+    end
+
+    should 'treat points not provided as zero' do
+      va = Flappi::Version.new([1], nil, nil)
+      vb = Flappi::Version.new([1, 0, 0], nil, nil)
+      assert va == vb
+
+      vc = Flappi::Version.new([1, 0, 1], nil, nil)
+      refute vc == vb
+    end
+
+    should 'match with wildcard' do
+      va = Flappi::Version.new([1, '*'], nil, nil)
+      vb = Flappi::Version.new([1, 3], nil, nil)
+      assert va == vb
+    end
+
+    should 'match flavours' do
+      va = Flappi::Version.new([1, 0], 'mobile', nil)
+      vb = Flappi::Version.new([1, 0], 'mobile', nil)
+      assert va == vb
+
+      vc = Flappi::Version.new([1, 0], nil, nil)
+      refute va == vc
+    end
+
+    should 'match wildcard flavours' do
+      va = Flappi::Version.new([1, 0], 'mobile', nil)
+      vb = Flappi::Version.new([1, 0], '*', nil)
+      assert va == vb
+    end
+  end
+
+  context 'not equal with !=' do
+    should 'return falsewhen exactly same' do
+      va = Flappi::Version.new([1, 0], nil, nil)
+      vb = Flappi::Version.new([1, 0], nil, nil)
+      refute va != vb
+    end
+  end
+
+  context 'comparators' do
+    setup do
+      @v2_0 = Flappi::Version.new([2, 0], nil, nil)
+      @v1_0 = Flappi::Version.new([1, 0], nil, nil)
+      @v1_1 = Flappi::Version.new([1, 1], nil, nil)
+    end
+
+    context 'with >' do
+      should 'return true when greater than on first' do
+        assert @v2_0 > @v1_0
+      end
+
+      should 'return false when less than on first' do
+        refute @v1_0 > @v2_0
+      end
+
+      should 'return true when greater than on second' do
+        assert @v1_1 > @v1_0
+      end
+
+      should 'return false when less than on second' do
+        refute @v1_0 > @v1_1
+      end
+
+      should 'return false when equal' do
+        refute @v1_1 > @v1_1
+      end
+
+      should 'match flavours' do
+        v1_1m = Flappi::Version.new([1, 1], 'mobile', nil)
+        v1_0m = Flappi::Version.new([1, 0], 'mobile', nil)
+        assert v1_1m > v1_0m
+      end
+
+      should 'match wildcard flavours' do
+        v1_1m = Flappi::Version.new([1, 1], 'mobile', nil)
+        v1_0star = Flappi::Version.new([1, 0], '*', nil)
+        assert v1_1m > v1_0star
+      end
+    end
+
+    context 'with >=' do
+      should 'return true when gt or equal' do
+        assert @v2_0 >= @v1_0
+        assert @v2_0 >= Flappi::Version.new([2, 0], nil, nil)
+        refute @v1_1 >= @v2_0
+      end
+    end
+
+    context 'with <' do
+      should 'return true when less than' do
+        refute @v2_0 < @v1_0
+        refute @v2_0 < Flappi::Version.new([2, 0], nil, nil)
+        assert @v1_1 < @v2_0
+      end
+    end
+
+    context 'with <=' do
+      should 'return true when lt or equal' do
+        refute @v2_0 <= @v1_0
+        assert @v2_0 <= Flappi::Version.new([2, 0], nil, nil)
+        assert @v1_1 <= @v2_0
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

This PR adds support for creating new api versions with a fallback to previous definitions.

### Ressources

- [Vimaly Ticket](https://vimaly.com/#j8mqm/t/api_v3_Implement_the_first_API_v3.0.0_endpoint/ue6DjWzhCcl4RNkBz)