### PR TITLE
Add ability to Return 204 for No Content.

### DIFF
--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -232,11 +232,8 @@ module Flappi
       response_object = controller.respond
 
       # return 204 no content when no content is given rather than parsing it as either `null` or `{}` with a 200 response.
-      # if you want to return an empty object (`{}`), just send an empty object.
-      # you can force a 204 with `status_code: 204` as well, which will strip all content and exit
-      if !response_object || (
-        response_object&.respond_to?(:status_code) && (response_object[:status_code] == :no_content || response_object[:status_code] == 204)
-      )
+      # this is only when you omit the build, eg just `def respond; end`
+      if !response_object
         return controller.head :no_content
       end
 

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -230,6 +230,16 @@ module Flappi
 
     def self.render_response_json(controller)
       response_object = controller.respond
+
+      # return 204 no content when no content is given rather than parsing it as either `null` or `{}` with a 200 response.
+      # if you want to return an empty object (`{}`), just send an empty object.
+      # you can force a 204 with `status_code: 204` as well, which will strip all content and exit
+      if !response_object || (
+        response_object&.respond_to?(:status_code) && (response_object[:status_code] == :no_content || response_object[:status_code] == 204)
+      )
+        return controller.head :no_content
+      end
+
       if response_object.respond_to?(:status_code)
         error_info = response_object.status_error_info
         response_hash = error_info.is_a?(String) ? { error: error_info } : { errors: error_info }

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -233,9 +233,7 @@ module Flappi
 
       # return 204 no content when no content is given rather than parsing it as either `null` or `{}` with a 200 response.
       # this is only when you omit the build, eg just `def respond; end`
-      if !response_object
-        return controller.head :no_content
-      end
+      return controller.head :no_content unless response_object
 
       if response_object.respond_to?(:status_code)
         error_info = response_object.status_error_info

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -234,6 +234,7 @@ module Flappi
       # return 204 no content when no content is given rather than parsing it as either `null` or `{}` with a 200 response.
       # this is only when you omit the build, eg just `def respond; end`
       return controller.head :no_content unless response_object
+      return controller.head :no_content if response_object.respond_to?(:status_code) && response_object.status_code == 204
 
       if response_object.respond_to?(:status_code)
         error_info = response_object.status_error_info

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -409,6 +409,11 @@ module Flappi
       @delegate.query(block)
     end
 
+    # From inside a query, return 204 NO CONTENT
+    def return_no_content
+      @delegate.return_no_content if @delegate.respond_to?(:return_no_content)
+    end
+
     # From inside a query, return an error
     # @param status_code (Integer) an HTTP status code to return
     # @param error_info (Object) a message String or an error hash to return

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -244,6 +244,10 @@ module Flappi
       @query_block = block
     end
 
+    def return_no_content
+      @status_code = 204
+    end
+
     def return_error(status_code, error_info)
       @status_code = status_code
       @status_error_info = error_info

--- a/test/examples/empty_object.rb
+++ b/test/examples/empty_object.rb
@@ -4,8 +4,7 @@ module Examples
   module EmptyObject
     include Flappi::Definition
 
-    def endpoint
-    end
+    def endpoint; end
 
     def respond
       build do

--- a/test/examples/empty_object.rb
+++ b/test/examples/empty_object.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Examples
+  module EmptyObject
+    include Flappi::Definition
+
+    def endpoint
+    end
+
+    def respond
+      build do
+        # this will return an empty object, not :no_content
+      end
+    end
+  end
+end

--- a/test/examples/no_content.rb
+++ b/test/examples/no_content.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Examples
+  module NoContent
+    include Flappi::Definition
+
+    def endpoint
+    end
+
+    def respond # literally no content
+    end
+  end
+end

--- a/test/examples/no_content.rb
+++ b/test/examples/no_content.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/RedundantReturn, Lint/MissingCopEnableDirective
+
 module Examples
   module NoContent
     include Flappi::Definition
 
-    def endpoint
-    end
+    def endpoint; end
 
-    def respond # literally no content
+    def respond
+      return # nothing; this will 204
     end
   end
 end

--- a/test/examples/no_content_return.rb
+++ b/test/examples/no_content_return.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Examples
+  module NoContentReturn
+    include Flappi::Definition
+
+    def endpoint
+      query do
+        return_no_content
+      end
+    end
+
+    def respond
+      build do
+      end
+    end
+  end
+end

--- a/test/integration/empty_object_test.rb
+++ b/test/integration/empty_object_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'pp'
+require_relative '../test_helper'
+require_relative '../examples/empty_object'
+
+module Examples
+  class EmptyObjectController < ExampleController
+  end
+end
+
+module Integration
+  class EmptyObjectTest < MiniTest::Test
+    context 'Response to EmptyObject' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'respond with an empty object' do
+        controller = Examples::EmptyObjectController.new
+        response = controller.show
+
+        refute_equal(:no_content, controller.last_head_params)
+        assert_equal({}, response)
+      end
+    end
+  end
+end

--- a/test/integration/exercise1_response_test.rb
+++ b/test/integration/exercise1_response_test.rb
@@ -8,7 +8,6 @@ require_relative '../examples/exercise1'
 
 module Examples
   class Exercise1Controller < ExampleController
-
     def initialize
       self.params = { extra: 50 }
     end
@@ -16,7 +15,6 @@ module Examples
     def request
       OpenStruct.new(query_parameters: params, url: 'http://test.api/exercise1')
     end
-
   end
 end
 

--- a/test/integration/exercise1_response_test.rb
+++ b/test/integration/exercise1_response_test.rb
@@ -7,29 +7,16 @@ require 'pp'
 require_relative '../examples/exercise1'
 
 module Examples
-  class Exercise1Controller
-    attr_accessor :params
-    attr_accessor :last_render_params
+  class Exercise1Controller < ExampleController
 
     def initialize
       self.params = { extra: 50 }
-    end
-
-    def show
-      Flappi.build_and_respond(self)
     end
 
     def request
       OpenStruct.new(query_parameters: params, url: 'http://test.api/exercise1')
     end
 
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
-    end
   end
 end
 

--- a/test/integration/exercise2_response_test.rb
+++ b/test/integration/exercise2_response_test.rb
@@ -9,25 +9,7 @@ require_relative '../examples/v2_version_plan'
 require_relative '../examples/exercise_model'
 
 module Examples
-  class Exercise2VersionedController
-    attr_accessor :params
-    attr_accessor :last_render_params
-
-    def show
-      Flappi.build_and_respond(self)
-    end
-
-    def request
-      OpenStruct.new(query_parameters: params)
-    end
-
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
-    end
+  class Exercise2VersionedController < ExampleController
   end
 end
 

--- a/test/integration/exercise3_response_test.rb
+++ b/test/integration/exercise3_response_test.rb
@@ -9,9 +9,7 @@ require_relative '../examples/v2_version_plan'
 require_relative '../examples/exercise_model'
 
 module Examples
-  class Exercise3Controller
-    attr_accessor :params
-    attr_accessor :last_render_params
+  class Exercise3Controller < ExampleController
 
     def my_method
       Flappi.build_and_respond(self, :my_method)
@@ -21,13 +19,6 @@ module Examples
       OpenStruct.new(query_parameters: params, raw_post: 'This is raw post data')
     end
 
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
-    end
   end
 end
 

--- a/test/integration/exercise3_response_test.rb
+++ b/test/integration/exercise3_response_test.rb
@@ -10,7 +10,6 @@ require_relative '../examples/exercise_model'
 
 module Examples
   class Exercise3Controller < ExampleController
-
     def my_method
       Flappi.build_and_respond(self, :my_method)
     end
@@ -18,7 +17,6 @@ module Examples
     def request
       OpenStruct.new(query_parameters: params, raw_post: 'This is raw post data')
     end
-
   end
 end
 

--- a/test/integration/exercise4_response_test.rb
+++ b/test/integration/exercise4_response_test.rb
@@ -7,29 +7,7 @@ require 'pp'
 require_relative '../examples/exercise4'
 
 module Examples
-  class Exercise4Controller
-    attr_accessor :params
-    attr_accessor :last_render_params
-
-    def initialize
-      self.params = {}
-    end
-
-    def show
-      Flappi.build_and_respond(self)
-    end
-
-    def request
-      OpenStruct.new(query_parameters: params)
-    end
-
-    def respond_to
-      yield JsonFormatter.new
-    end
-
-    def render(params)
-      self.last_render_params = params
-    end
+  class Exercise4Controller < ExampleController
   end
 end
 

--- a/test/integration/no_content_return_test.rb
+++ b/test/integration/no_content_return_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'pp'
+require_relative '../test_helper'
+require_relative '../examples/no_content_return'
+
+module Examples
+  class NoContentReturnController < ExampleController
+  end
+end
+
+module Integration
+  class NoContentReturnTest < MiniTest::Test
+    context 'Response to NoContentReturn' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'respond :no_content the stubbed controller head method when content is falsey' do
+        controller = Examples::NoContentReturnController.new
+        controller.show # doesn't return anything useful; not an actual response
+
+        assert_equal(:no_content, controller.last_head_params)
+      end
+    end
+  end
+end

--- a/test/integration/no_content_test.rb
+++ b/test/integration/no_content_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'pp'
+require_relative '../test_helper'
+require_relative '../examples/no_content'
+
+module Examples
+  class NoContentController < ExampleController
+  end
+end
+
+module Integration
+  class NoContentTest < MiniTest::Test
+    context 'Response to NoContent' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'respond :no_content the stubbed controller head method when content is falsey' do
+        controller = Examples::NoContentController.new
+        controller.show # doesn't return anything useful; not an actual response
+
+        assert_equal(:no_content, controller.last_head_params)
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,3 +36,31 @@ class JsonFormatter
     yield
   end
 end
+
+module Examples
+  class ExampleController
+    # this is a stub of a controller, think ActionController
+    attr_accessor :params
+    attr_accessor :last_render_params
+
+    def initialize
+      self.params = {}
+    end
+
+    def show
+      Flappi.build_and_respond(self)
+    end
+
+    def request
+      OpenStruct.new(query_parameters: params)
+    end
+
+    def respond_to
+      yield JsonFormatter.new
+    end
+
+    def render(params)
+      self.last_render_params = params
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,6 +42,7 @@ module Examples
     # this is a stub of a controller, think ActionController
     attr_accessor :params
     attr_accessor :last_render_params
+    attr_accessor :last_head_params
 
     def initialize
       self.params = {}
@@ -61,6 +62,10 @@ module Examples
 
     def render(params)
       self.last_render_params = params
+    end
+
+    def head(params)
+      self.last_head_params = params
     end
   end
 end


### PR DESCRIPTION
Returning nothing from `respond` will now result in a 204.

Also, refactors tests by adding (and extending from) a `Example::ExampleController` in `test_helper`.

Usage:

```
def respond
  return unless params[:actually_respond]
  build do
    # ...
  end
end
```
or (inside a query block)
```
  query do
    # …
    return_no_content
  end
```

Eg. when I want to delete:

```
def endpoint
  …
  query do
    delete(params[:id])
    return_no_content
  end
end

def respond
  build do
    # respond with a 204
  end
end
```

I couldn't find a better way to do this – returning `return head :no_status` directly in the `respond` method would result in multiple headers sent.  Likely I'm overlooking something more obvious that I don't know about ActionController.