### PR TITLE
Don't duplicate path in the `link` response.

### DIFF
--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -344,6 +344,8 @@ module Flappi
 
     def expand_uri_with_host(subst_uri)
       expanded = controller_base_url
+      return expanded if expanded.ends_with?(subst_uri.path) # so we don't get `/holdings/1234/holdings/1234` when `controller_base_url` is wrong.
+
       expanded += '/' unless expanded[-1] == '/' || subst_uri.path[0] == '/'
       expanded + subst_uri.path
     end

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -344,7 +344,7 @@ module Flappi
 
     def expand_uri_with_host(subst_uri)
       expanded = controller_base_url
-      return expanded if expanded.ends_with?(subst_uri.path) # so we don't get `/holdings/1234/holdings/1234` when `controller_base_url` is wrong.
+      return expanded if expanded.end_with?(subst_uri.path) # so we don't get `/holdings/1234/holdings/1234` when `controller_base_url` is wrong.
 
       expanded += '/' unless expanded[-1] == '/' || subst_uri.path[0] == '/'
       expanded + subst_uri.path


### PR DESCRIPTION
Somehow with `path '/holdings/:holding_id'`, `link` (eg. `:self`) is malformed and returns `localhost…/holdings/1234/holdings/1234`.

This is because inside `lib/flappi/response_builder.rb#controller_base_url`, `source_definition.endpoint_info[:path]` is mutated to be `/holdings/1234`, not the original `/holdings/:holding_id`.

I couldn't find the source of the mutation, so I decided to give a very rough example of it wrongly "fixed" in this PR.

Is there a better way to get `controller_base_url`?  This seems weird.