### PR TITLE
Remove required trailing slash on controller_base_url regex.

### DIFF
--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -308,7 +308,8 @@ module Flappi
 
     def controller_base_url
       raise 'path not defined in endpoint' unless source_definition.endpoint_info[:path]
-      path_matcher = Regexp.new source_definition.endpoint_info[:path].gsub(/\/:\w+\//, '\/[^\/]+\/')
+      path = source_definition.endpoint_info[:path].gsub(/\/$/, '') # remove trailing slash
+      path_matcher = Regexp.new(path.gsub(/\/:\w+/, '\/[^\/]+')) # converts `/user/:user_id` into `/user/[^\/]+`
 
       # puts "Using matcher #{path_matcher} on #{controller_url}"
       matches = controller_url.match(path_matcher)


### PR DESCRIPTION
Thanks @richdrich I think I got it – I was looking in the wrong place when it was really just a trailing slash issue.

----

This allows `/holdings/:holding_id` to be valid when previously it must have been `/holdings/:holding_id/` – while trailing slashes don't work on other paths, like `/holdings/:holding_id/trades`.

Works with all `path`s in Investapp API v2, eg:
 -`/portfolios/:portfolio_id/holdings`
- `/portfolios/:portfolio_id`

Still works with the old solution, eg:
- `/portfolios/:portfolio_id/` (not used inside Investapp)