### PR TITLE
Encode links before creating `link` urls.

### DIFF
--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.name        = 'flappi'
   s.version     = '0.8.0'
-  s.date        = '2018-07-24'
+  s.date        = '2018-08-13'
   s.summary     = 'Flappi API Builder'
   s.description = 'A flexible DSL-based API builder'
   s.authors     = ['Richard Parratt', 'Sharesight']

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'flappi'
-  s.version     = '0.7.0'
-  s.date        = '2018-07-17'
+  s.version     = '0.8.0'
+  s.date        = '2018-07-24'
   s.summary     = 'Flappi API Builder'
   s.description = 'A flexible DSL-based API builder'
   s.authors     = ['Richard Parratt', 'Sharesight']

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -356,11 +356,16 @@ module Flappi
     def substitute_link_path_params(path)
       subst_path = path.dup
       used_params = []
+
       controller_params.each do |pname, pvalue|
         subex = /:#{pname}([^\w]|\z)/
         # puts "Try #{pname}=#{pvalue}, subex=#{subex} on #{subst_path}"
         if subst_path.match?(subex)
-          subst_path.gsub!(subex, "#{pvalue}\\1")
+          # Since we're building a URL, we need to ensure it's encoded properly.
+          # Fortunately, it appears Ruby will unencode url parameters for us, so we don't need to unencode `foo%20bar` here.
+          # When this is used later, we need the encoded value.
+          escaped_value = ::CGI.escape(pvalue.to_s)
+          subst_path.gsub!(subex, "#{escaped_value}\\1")
           used_params << pname.to_sym
         end
       end

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -360,15 +360,14 @@ module Flappi
 
       controller_params.each do |pname, pvalue|
         subex = /:#{pname}([^\w]|\z)/
-        # puts "Try #{pname}=#{pvalue}, subex=#{subex} on #{subst_path}"
-        if subst_path.match?(subex)
-          # Since we're building a URL, we need to ensure it's encoded properly.
-          # Fortunately, it appears Ruby will unencode url parameters for us, so we don't need to unencode `foo%20bar` here.
-          # When this is used later, we need the encoded value.
-          escaped_value = ::CGI.escape(pvalue.to_s)
-          subst_path.gsub!(subex, "#{escaped_value}\\1")
-          used_params << pname.to_sym
-        end
+        next unless subst_path.match?(subex)
+
+        # Since we're building a URL, we need to ensure it's encoded properly.
+        # Fortunately, it appears Ruby will unencode url parameters for us, so we don't need to unencode `foo%20bar` here.
+        # When this is used later, we need the encoded value.
+        escaped_value = ::CGI.escape(pvalue.to_s)
+        subst_path.gsub!(subex, "#{escaped_value}\\1")
+        used_params << pname.to_sym
       end
 
       # puts "Made path #{subst_path}"

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -2,6 +2,7 @@
 
 # Build an API response from a definition
 require 'uri'
+require 'cgi'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/hash/indifferent_access'
 

--- a/test/response_builder_test.rb
+++ b/test/response_builder_test.rb
@@ -208,21 +208,21 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
 
           should 'work with spaces and basic symbols' do
             @encoded_response_builder.controller_url = 'http://server/test/endpoint/foo bar!@#$%^&*()_+{}:"<>?/,.;[]-='
-            @encoded_response_builder.controller_params.merge!({ name: 'foo bar!@#$%^&*()_+{}:"<>?/,.;[]-=' })
+            @encoded_response_builder.controller_params[:name] = 'foo bar!@#$%^&*()_+{}:"<>?/,.;[]-='
             @encoded_response_builder.source_definition.path '/endpoint/:name'
 
             built_response = @encoded_response_builder.build({}) do
               @encoded_response_builder.link(:self)
             end
 
-            assert_equal({ 'links' => {
-              'self' => 'http://server/test/endpoint/foo+bar%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D%3A%22%3C%3E%3F%2F%2C.%3B%5B%5D-%3D',
-            }}, built_response)
+            assert_equal({ 'links' => { 'self' => 'http://server/test/endpoint/foo+bar%21%40%23%24%25%5E%26%2A%28%29_%2B%7B%7D%3A%22%3C%3E%3F%2F%2C.%3B%5B%5D-%3D' } },
+                         built_response)
           end
 
           should 'properly encode a plus as %2B rather than a space via params' do
             @encoded_response_builder.controller_url = 'http://server/test/endpoint/foo+bar' # this is `foo bar` to a browser
-            @encoded_response_builder.controller_params.merge!({ name: 'foo bar', other: '1+2' })
+            @encoded_response_builder.controller_params[:name] = 'foo bar'
+            @encoded_response_builder.controller_params[:other] = '1+2'
             @encoded_response_builder.source_definition.path '/endpoint/:name'
 
             built_response = @encoded_response_builder.build({}) do
@@ -230,13 +230,11 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
               @encoded_response_builder.link(key: :other, path: '/other_endpoint?other=:other')
             end
 
-            assert_equal({ 'links' => {
-              'self' => 'http://server/test/endpoint/foo+bar',
-              'other' => 'http://server/test/other_endpoint?other=1%2B2',
-            }}, built_response)
+            assert_equal({ 'links' => { 'self' => 'http://server/test/endpoint/foo+bar',
+                                        'other' => 'http://server/test/other_endpoint?other=1%2B2' } },
+                         built_response)
           end
         end
-
       end
 
       context 'field' do


### PR DESCRIPTION
I believe this won't have any have side-effects and Rails will always properly decode parameters, so sending `api/…/foo%20bar` will result in a param of `foo bar`, right?

Also bumps the version – as Thorsten reminded me, this is a bad idea.