### PR TITLE
Add support for multiple request and response examples, and more API errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,9 @@ Lint/UselessComparison:
 
 Layout/AlignParameters:
   Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+Style/EmptyLineAfterGuardClause:
+  Enabled: false

--- a/lib/flappi/api_doc_formatter.rb
+++ b/lib/flappi/api_doc_formatter.rb
@@ -21,7 +21,7 @@ module Flappi
       return nil if doc.nil?
 
       template_path = "#{Pathname.new(method(:format).source_location.first).dirname}/api_doc_template.rb.erb"
-      template = ERB.new File.read(template_path), nil, '%'
+      template = ERB.new File.read(template_path), nil, '-'
       template.result(doc.instance_eval { binding })
     end
   end

--- a/lib/flappi/api_doc_template.rb.erb
+++ b/lib/flappi/api_doc_template.rb.erb
@@ -15,16 +15,18 @@
   <%= param_item.description %>
 <% end %>
 
-@apiParamExample Request Example
-{<%= endpoint.method_name %>} <%= endpoint.request_example %>
+@apiParamExample <%= endpoint.request_example[:label] || 'Request Example' %>
+{<%= endpoint.method_name %>} <%= endpoint.request_example[:content] %>
 
 <% for response_item in response %>
 @apiSuccess (200 Success) {<%= response_item.type %>} <%= qname_from(response_item.name) %>
 <%= response_item.description %>
 <% end %>
 
-@apiSuccessExample {json} Response Example
-<%= endpoint.response_example %>
+<% if endpoint.response_example -%>
+@apiSuccessExample {json} <%= endpoint.response_example[:label] || 'Response Example' %>
+<%= endpoint.response_example[:content] %>
+<% end -%>
 
 @apiError (400 Bad Request) {Integer} error
   Internal error code

--- a/lib/flappi/api_doc_template.rb.erb
+++ b/lib/flappi/api_doc_template.rb.erb
@@ -38,4 +38,9 @@
   Detailed error message what went wrong.
 
 @apiUse OauthErrors
+
+<% (endpoint.api_errors || []).each do |api_error| -%>
+@apiError (<%= api_error[:status_code] %>) {Hash} <%= api_error[:response_field_name] %>
+  <%= api_error[:response_field_description] %>
+<% end -%>
 =end

--- a/lib/flappi/api_doc_template.rb.erb
+++ b/lib/flappi/api_doc_template.rb.erb
@@ -15,17 +15,19 @@
   <%= param_item.description %>
 <% end %>
 
-@apiParamExample <%= endpoint.request_example[:label] || 'Request Example' %>
-{<%= endpoint.method_name %>} <%= endpoint.request_example[:content] %>
+<% (endpoint.request_examples || []).each do |request_example| -%>
+@apiParamExample <%= request_example[:label] || 'Request Example' %>
+{<%= endpoint.method_name %>} <%= request_example[:content] %>
+<% end -%>
 
 <% for response_item in response %>
 @apiSuccess (200 Success) {<%= response_item.type %>} <%= qname_from(response_item.name) %>
 <%= response_item.description %>
 <% end %>
 
-<% if endpoint.response_example -%>
-@apiSuccessExample {json} <%= endpoint.response_example[:label] || 'Response Example' %>
-<%= endpoint.response_example[:content] %>
+<% (endpoint.response_examples || []).each do |response_example| -%>
+@apiSuccessExample {json} <%= response_example[:label] || 'Response Example' %>
+<%= response_example[:content] %>
 <% end -%>
 
 @apiError (400 Bad Request) {Integer} error

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -149,7 +149,8 @@ module Flappi
           api_group: documenter_definition.endpoint_info[:group],
           api_version: documenter_definition.document_as_version(for_version),
           response_examples: documenter_definition.endpoint_info[:response_examples],
-          request_examples: request_examples
+          request_examples: request_examples,
+          api_errors: documenter_definition.endpoint_info[:api_errors]
         },
 
         # Query parameters, etc

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -136,6 +136,8 @@ module Flappi
     end
 
     def self.make_documentation_result(definition, documenter_definition, for_version, param_docs, path)
+      request_examples = documenter_definition.endpoint_info[:request_examples]
+      request_examples = [{ content: "\"#{path}\"" }] if !request_examples || request_examples.empty?
       {
         endpoint: {
           title: documenter_definition.endpoint_info[:title] || documenter_definition.endpoint_info[:description],
@@ -146,8 +148,8 @@ module Flappi
           api_name: definition.name.demodulize,
           api_group: documenter_definition.endpoint_info[:group],
           api_version: documenter_definition.document_as_version(for_version),
-          response_example: documenter_definition.endpoint_info[:response_example],
-          request_example: documenter_definition.endpoint_info[:request_example] || { content: "\"#{path}\"" }
+          response_examples: documenter_definition.endpoint_info[:response_examples],
+          request_examples: request_examples
         },
 
         # Query parameters, etc

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -147,7 +147,7 @@ module Flappi
           api_group: documenter_definition.endpoint_info[:group],
           api_version: documenter_definition.document_as_version(for_version),
           response_example: documenter_definition.endpoint_info[:response_example],
-          request_example: documenter_definition.endpoint_info[:request_example] || "\"#{path}\""
+          request_example: documenter_definition.endpoint_info[:request_example] || { content: "\"#{path}\"" }
         },
 
         # Query parameters, etc

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -131,7 +131,7 @@ module Flappi
     def self.make_param_docs(documenter_definition, path)
       param_docs = documenter_definition.endpoint_info[:params]
       param_docs.select { |p| path.match ":#{p[:name]}(/|$)" }.each { |p| p[:optional] = false }
-      param_docs.reject! {|p| p[:hidden] }
+      param_docs.reject! { |p| p[:hidden] }
       param_docs
     end
 
@@ -156,7 +156,7 @@ module Flappi
     end
 
     # validate actual parameters against definitions, return an error message if fails
-    def self.validate_parameters(actual_params, defined_params, strict_mode=false)
+    def self.validate_parameters(actual_params, defined_params, strict_mode = false)
       defined_params.each do |defined_param|
         Flappi::Utils::Logger.d "Check parameter #{defined_param}"
         param_supplied = actual_params.key? defined_param[:name]
@@ -177,12 +177,12 @@ module Flappi
       if strict_mode
         rails_params = ['format', 'version', 'controller', 'action', 'access_token']
         param_hash = if actual_params.respond_to?(:to_unsafe_h)
-              actual_params.to_unsafe_h
-            else
-              actual_params.to_h
-            end
+                       actual_params.to_unsafe_h
+                     else
+                       actual_params.to_h
+                     end
         wrong_params = pathify_hash(nil, param_hash) - \
-          (defined_params.map {|p| p[:name].to_s } + rails_params)
+                       (defined_params.map { |p| p[:name].to_s } + rails_params)
 
         return ["Parameter(s) #{wrong_params.join(', ')} not recognised in strict mode", :not_acceptable] if wrong_params.present?
       end
@@ -191,7 +191,7 @@ module Flappi
     end
 
     def self.pathify_hash(prefix, h)
-      h.flat_map do |k,v|
+      h.flat_map do |k, v|
         prefixed_k = [prefix, k].compact.map(&:to_s).join('/')
         if v.is_a?(Hash)
           pathify_hash(prefixed_k, v)

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -353,7 +353,10 @@ module Flappi
                       end
       return unless version_wanted(options)
 
-      endpoint_info["#{example_type}_example".to_sym] = text
+      endpoint_info["#{example_type}_example".to_sym] = {
+        label: options[:label],
+        content: text
+      }
     end
 
     # Define an input parameter (inline or query string)

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -417,7 +417,7 @@ module Flappi
 
     # Enable/disable strict mode, unknown parameters will cause an error\
     # Default is to disable this
-    def strict(mode=false)
+    def strict(mode = false)
       endpoint_info[:strict_mode] = mode
     end
 

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -54,7 +54,7 @@ module Flappi
 
     # @private
     def endpoint_info
-      @endpoint_info ||= { params: [] }
+      @endpoint_info ||= { params: [], request_examples: [], response_examples: [] }
     end
 
     # @private
@@ -353,7 +353,7 @@ module Flappi
                       end
       return unless version_wanted(options)
 
-      endpoint_info["#{example_type}_example".to_sym] = {
+      endpoint_info["#{example_type}_examples".to_sym] << {
         label: options[:label],
         content: text
       }

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -54,7 +54,7 @@ module Flappi
 
     # @private
     def endpoint_info
-      @endpoint_info ||= { params: [], request_examples: [], response_examples: [] }
+      @endpoint_info ||= { params: [], request_examples: [], response_examples: [], api_errors: [] }
     end
 
     # @private
@@ -341,6 +341,15 @@ module Flappi
     # @param v (String) The request example URL
     def request_example(*v)
       set_example('request', v)
+    end
+
+    # Define an API error
+    def api_error(status_code, field_name, field_description)
+      endpoint_info[:api_errors] << {
+        status_code: status_code,
+        response_field_name: field_name,
+        response_field_description: field_description
+      }
     end
 
     # @private

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -40,10 +40,10 @@ module Flappi
         # construct a model of type with the parameters
         # which we should have by virtue of being mixed into the controller
         base_object = if options.key?(:options)
-          options[:type].where(controller_params, options[:options])
-        else
-          options[:type].where(controller_params)
-        end
+                        options[:type].where(controller_params, options[:options])
+                      else
+                        options[:type].where(controller_params)
+                      end
       end
 
       # If return_error called, return a struct

--- a/lib/flappi/utils/param_types.rb
+++ b/lib/flappi/utils/param_types.rb
@@ -28,7 +28,7 @@ module Flappi
         end
       end
 
-      def cast_param(src, type, name=nil)
+      def cast_param(src, type, name = nil)
         # puts "cast_param #{src}, type #{type.to_s}"
         return nil if src.nil?
 
@@ -43,8 +43,8 @@ module Flappi
           return src if src.is_a?(Date)
           Date.parse(src)
         when 'Array'
-           return src if src.is_a?(Array)
-           array_parse(src)
+          return src if src.is_a?(Array)
+          array_parse(src)
         when 'String'
           src
         else
@@ -54,11 +54,11 @@ module Flappi
       end
 
       def array_parse(a)
-        raise "Incorrect array" unless a.start_with?('[') and a.end_with?(']')
+        raise "Incorrect array" unless a.start_with?('[') && a.end_with?(']')
         a[1..-2].split(',').map do |c|
           return c.to_f if c.to_f.to_s == c
           return c.to_i if c.to_i.to_s == c
-          c.gsub(/^"/,'').gsub(/"\s*$/, '')
+          c.gsub(/^"/, '').gsub(/"\s*$/, '')
         end
       end
     end

--- a/test/examples/exercise2_2.0_doc.rb
+++ b/test/examples/exercise2_2.0_doc.rb
@@ -32,8 +32,6 @@
 
 
 
-@apiSuccessExample {json} Response Example
-
 
 @apiError (400 Bad Request) {Integer} error
  Internal error code

--- a/test/examples/exercise2_2.0_doc.rb
+++ b/test/examples/exercise2_2.0_doc.rb
@@ -41,4 +41,5 @@
  Detailed error message what went wrong.
 
 @apiUse OauthErrors
+
 =end

--- a/test/examples/exercise4_doc.rb
+++ b/test/examples/exercise4_doc.rb
@@ -36,4 +36,5 @@ Second field (how)
   Detailed error message what went wrong.
 
 @apiUse OauthErrors
+
 =end

--- a/test/examples/exercise7_doc.rb
+++ b/test/examples/exercise7_doc.rb
@@ -45,4 +45,5 @@
   Detailed error message what went wrong.
 
 @apiUse OauthErrors
+
 =end

--- a/test/examples/exercise8.rb
+++ b/test/examples/exercise8.rb
@@ -9,7 +9,7 @@ module Examples
       http_method 'GET'
       path '/examples/exercise8'
       title 'Exercise API 8'
-      description 'Exercise #{definition DSL #1}8 - test strict mode'
+      description 'Exercise 8 - test strict mode'
       param(:required, type: Integer, doc: 'Required parameter', optional: false)
       param(:opt, type: Integer, doc: 'Optional parameter', optional: true)
       param('nested/nest_opt', type: Integer, doc: 'Nested optional parameter', optional: true)

--- a/test/examples/exercise9.rb
+++ b/test/examples/exercise9.rb
@@ -37,6 +37,8 @@ module Examples
       link :other, 'other/:defaulted/other_api?extra=:extra'
       link :self
 
+      request_example('"/api/examples/exercise?extra=100"')
+      request_example({ label: 'Another Request Example' }, '"/api/examples/exercise?extra=100"')
       request_example({ label: 'Special Request Example' }, '"/api/examples/exercise?extra=100"')
 
       example_text = <<~END_EXAMPLE
@@ -48,6 +50,8 @@ module Examples
           ]
         }
       END_EXAMPLE
+      response_example(example_text)
+      response_example({ label: 'Another Response Example' }, example_text)
       response_example({ label: 'Special Response Example' }, example_text)
     end
 

--- a/test/examples/exercise9.rb
+++ b/test/examples/exercise9.rb
@@ -53,6 +53,9 @@ module Examples
       response_example(example_text)
       response_example({ label: 'Another Response Example' }, example_text)
       response_example({ label: 'Special Response Example' }, example_text)
+
+      api_error '404 Not Found', 'error_code', 'Internal ID to identify the root cause'
+      api_error '404 Not Found', 'error', 'Error details'
     end
 
     def respond

--- a/test/examples/exercise9.rb
+++ b/test/examples/exercise9.rb
@@ -38,7 +38,7 @@ module Examples
       link :self
 
       request_example('"/api/examples/exercise?extra=100"')
-      response_example({ label: 'Special Response Example' }, <<~END_EXAMPLE
+      example_text = <<~END_EXAMPLE
         {
           extra_plus_1: 101,
           rows: [
@@ -47,7 +47,7 @@ module Examples
           ]
         }
       END_EXAMPLE
-      )
+      response_example({ label: 'Special Response Example' }, example_text)
     end
 
     def respond

--- a/test/examples/exercise9.rb
+++ b/test/examples/exercise9.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Examples
+  module Exercise9
+    include Flappi::Definition
+
+    # Strictly to test which folder this came from.  This would not be in a real definition folder.
+    # see test/definition_locator_test.rb
+    def self.definition_source
+      'examples'
+    end
+
+    def endpoint
+      group 'Test_Exercise'
+      http_method 'GET'
+      path '/examples/exercise1'
+      title 'Exercise API 9'
+      description 'Exercise definition DSL #9'
+      param(:extra, type: Integer, doc: 'An extra query parameter', optional: true).processor do |value|
+        value || 1234
+      end
+
+      param :defaulted, type: Integer, doc: 'Parameter with default', default: 123
+      param :hidden_param, type: Integer, hidden: true, optional: true
+
+      query do |params|
+        if params[:return_error]
+          return_error 422, 'Eek!'
+        elsif params[:return_error_hash]
+          return_error(422, e: 'Fail', reason: 'wanted')
+        else
+          [{ n: 1, name: 'one' },
+           { n: 2, name: 'two' }]
+        end
+      end
+
+      link :other, 'other/:defaulted/other_api?extra=:extra'
+      link :self
+
+      request_example('"/api/examples/exercise?extra=100"')
+      response_example({ label: 'Special Response Example' }, <<~END_EXAMPLE
+        {
+          extra_plus_1: 101,
+          rows: [
+            { n: 1, name: 'one', alt_name: 'one' },
+            { n: 2, name: 'two', alt_name: 'one' }
+          ]
+        }
+      END_EXAMPLE
+      )
+    end
+
+    def respond
+      build do
+        field :extra, (params[:extra] || 0) + 100
+        field :defaulted, params[:defaulted]
+
+        objects name: :data do |row|
+          field :n, row[:n]
+          field :name, row[:name]
+          field :alt_name, source: :name
+        end
+      end
+    end
+  end
+end

--- a/test/examples/exercise9.rb
+++ b/test/examples/exercise9.rb
@@ -37,7 +37,8 @@ module Examples
       link :other, 'other/:defaulted/other_api?extra=:extra'
       link :self
 
-      request_example('"/api/examples/exercise?extra=100"')
+      request_example({ label: 'Special Request Example' }, '"/api/examples/exercise?extra=100"')
+
       example_text = <<~END_EXAMPLE
         {
           extra_plus_1: 101,

--- a/test/examples/exercise9_doc.rb
+++ b/test/examples/exercise9_doc.rb
@@ -18,6 +18,10 @@
   Parameter with default
 
 
+@apiParamExample Request Example
+{GET} "/api/examples/exercise?extra=100"
+@apiParamExample Another Request Example
+{GET} "/api/examples/exercise?extra=100"
 @apiParamExample Special Request Example
 {GET} "/api/examples/exercise?extra=100"
 
@@ -40,6 +44,24 @@
 @apiSuccess (200 Success) {String} data.alt_name
 
 
+
+@apiSuccessExample {json} Response Example
+{
+  extra_plus_1: 101,
+  rows: [
+    { n: 1, name: 'one', alt_name: 'one' },
+    { n: 2, name: 'two', alt_name: 'one' }
+  ]
+}
+
+@apiSuccessExample {json} Another Response Example
+{
+  extra_plus_1: 101,
+  rows: [
+    { n: 1, name: 'one', alt_name: 'one' },
+    { n: 2, name: 'two', alt_name: 'one' }
+  ]
+}
 
 @apiSuccessExample {json} Special Response Example
 {

--- a/test/examples/exercise9_doc.rb
+++ b/test/examples/exercise9_doc.rb
@@ -81,4 +81,9 @@
   Detailed error message what went wrong.
 
 @apiUse OauthErrors
+
+@apiError (404 Not Found) {Hash} error_code
+  Internal ID to identify the root cause
+@apiError (404 Not Found) {Hash} error
+  Error details
 =end

--- a/test/examples/exercise9_doc.rb
+++ b/test/examples/exercise9_doc.rb
@@ -18,7 +18,7 @@
   Parameter with default
 
 
-@apiParamExample Request Example
+@apiParamExample Special Request Example
 {GET} "/api/examples/exercise?extra=100"
 
 

--- a/test/examples/exercise9_doc.rb
+++ b/test/examples/exercise9_doc.rb
@@ -1,0 +1,62 @@
+=begin
+@api {GET} /examples/exercise1.json Exercise API 9
+
+@apiName Exercise9
+@apiGroup Test_Exercise
+@apiVersion 0.0.0
+
+@apiDescription
+  Exercise definition DSL #9
+
+@apiUse OAuthHeaders
+
+
+@apiParam {Integer} [extra]
+  An extra query parameter
+
+@apiParam {Integer} [defaulted=123]
+  Parameter with default
+
+
+@apiParamExample Request Example
+{GET} "/api/examples/exercise?extra=100"
+
+
+@apiSuccess (200 Success) {String} extra
+
+
+@apiSuccess (200 Success) {String} defaulted
+
+
+@apiSuccess (200 Success) {String[]} data
+
+
+@apiSuccess (200 Success) {String} data.n
+
+
+@apiSuccess (200 Success) {String} data.name
+
+
+@apiSuccess (200 Success) {String} data.alt_name
+
+
+
+@apiSuccessExample {json} Special Response Example
+{
+  extra_plus_1: 101,
+  rows: [
+    { n: 1, name: 'one', alt_name: 'one' },
+    { n: 2, name: 'two', alt_name: 'one' }
+  ]
+}
+
+
+@apiError (400 Bad Request) {Integer} error
+  Internal error code
+@apiError (400 Bad Request) {Integer} transaction_id
+  Unique identifier for this API transaction.
+@apiError (400 Bad Request) {Integer} reason
+  Detailed error message what went wrong.
+
+@apiUse OauthErrors
+=end

--- a/test/examples/exercise_model.rb
+++ b/test/examples/exercise_model.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 module Examples
-
   class ExerciseModel
     attr_accessor :params, :options
 
-    def self.where(params, options={})
+    def self.where(params, options = {})
       res = ExerciseModel.new
 
       res.params = params

--- a/test/integration/exercise2_doco_test.rb
+++ b/test/integration/exercise2_doco_test.rb
@@ -28,7 +28,7 @@ module Integration
     end
 
     def spaceless(s)
-      s.gsub(/ +/, ' ').gsub(/^ *$/,'')
+      s.gsub(/ +/, ' ').gsub(/^ *$/, '')
     end
   end
 end

--- a/test/integration/exercise2_response_test.rb
+++ b/test/integration/exercise2_response_test.rb
@@ -27,7 +27,7 @@ module Integration
         controller.params = { required: 2.718, version: 'v2.1.0-mobile' }
         response = controller.show
 
-        assert_equal({ 'all' => 'all_versions', 'v2_1_only' => 2.1, "params"=>{"required"=>2.718, "version"=>"v2.1.0-mobile"}, "options"=>{"test"=>"hello"} },
+        assert_equal({ 'all' => 'all_versions', 'v2_1_only' => 2.1, "params" => {"required" => 2.718, "version" => "v2.1.0-mobile"}, "options" => {"test" => "hello"} },
                      response)
       end
 
@@ -36,7 +36,7 @@ module Integration
         controller.params = { required: 3.142, version: 'v2.0-mobile' }
         response = controller.show
 
-        assert_equal({ 'all' => 'all_versions', 'v2_0_only' => 2.0, "params"=>{"required"=>3.142, "version"=>"v2.0-mobile"}, "options"=>{"test"=>"hello"} },
+        assert_equal({ 'all' => 'all_versions', 'v2_0_only' => 2.0, "params" => {"required" => 3.142, "version" => "v2.0-mobile"}, "options" => {"test" => "hello"} },
                      response)
       end
 

--- a/test/integration/exercise7_response_test.rb
+++ b/test/integration/exercise7_response_test.rb
@@ -37,7 +37,7 @@ module Integration
         response = @controller.update
 
         assert_equal({ 'obj' => { 'nested' => 'hello' },
-                       "links"=>{"self"=>"http://test.api/exercise7/examples/exercise7"} }, response)
+                       "links" => {"self" => "http://test.api/exercise7/examples/exercise7"} }, response)
       end
     end
   end

--- a/test/integration/exercise8_strict_test.rb
+++ b/test/integration/exercise8_strict_test.rb
@@ -52,9 +52,9 @@ module Integration
         response = @controller.show
         refute response
 
-        assert_equal({:json=>"{\"error\":\"Parameter required is required\"}",
-                      :plain=>"Parameter required is required",
-                      :status=>:not_acceptable}, @controller.last_render_params)
+        assert_equal({json: "{\"error\":\"Parameter required is required\"}",
+                      plain: "Parameter required is required",
+                      status: :not_acceptable}, @controller.last_render_params)
       end
 
       should 'fail when unrecognized parameter' do
@@ -62,9 +62,9 @@ module Integration
         response = @controller.show
         refute response
 
-        assert_equal({:json=>"{\"error\":\"Parameter(s) unwanted not recognised in strict mode\"}",
-         :plain=>"Parameter(s) unwanted not recognised in strict mode",
-         :status=>:not_acceptable}, @controller.last_render_params)
+        assert_equal({json: "{\"error\":\"Parameter(s) unwanted not recognised in strict mode\"}",
+                      plain: "Parameter(s) unwanted not recognised in strict mode",
+                      status: :not_acceptable}, @controller.last_render_params)
       end
     end
   end

--- a/test/integration/exercise9_response_label_doco_test.rb
+++ b/test/integration/exercise9_response_label_doco_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require 'pp'
+
+require_relative '../examples/exercise9'
+
+module Integration
+  class Exercise1DocoTest < MiniTest::Test
+    context 'Documentation of Exercise1' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+      end
+
+      should 'document our endpoint' do
+        doc_data = ::Flappi::BuilderFactory.document(::Examples::Exercise9, nil)
+        doc_text = ::Flappi::ApiDocFormatter.format_to_text(doc_data)
+
+        expected_doc_text = File.read('test/examples/exercise9_doc.rb')
+        # File.write 'test/examples/NEW_exercise9_doc.rb', doc_text
+        assert_equal expected_doc_text.to_s, doc_text.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
First step: add support for response example labels

```ruby
response_example({ label: 'Successful Response' }, '... the response content...')
```

Second step: add support for request example labels

```ruby
request_example({ label: 'Special Request' }, '... the request content...')
```

Third step: add support for multiple request and response examples

```ruby
request_example('... the request content...')
request_example({ label: 'Another Request' }, '... the request content...')
request_example({ label: 'Special Request' }, '... the request content...')

response_example('... the response content...')
response_example({ label: 'Another Response' }, '... the response content...')
response_example({ label: 'Successful Response' }, '... the response content...')
```


