### PR TITLE
Support the `version` parameter on a `param`, allowing parameters to be supported and documented on a per-version basis

### DIFF
--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -319,6 +319,7 @@ module Flappi
     # This assumes that a version plan (which defines semantic versioning and version flavours) is configured into Flappi.
     #
     # @option version_rule [String] :equals A version which must be matched for the endpoint to be supported. The version can be wildcarded with '*'.
+    # @option version_rule [String] :matches Synonym for equals
     def version(version_rule)
       raise "No version plan is defined - cannot use 'version'" unless version_plan
 

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -416,6 +416,8 @@ module Flappi
       def_args = extract_definition_args(args_or_name)
       require_arg def_args, :name
 
+      return unless version_wanted(def_args)
+
       param_def = { name: def_args[:name],
                     type: name_for_type(def_args[:type]),
                     default_doc: def_args[:default_doc],

--- a/lib/flappi/version_plan.rb
+++ b/lib/flappi/version_plan.rb
@@ -108,7 +108,7 @@ module Flappi
       supported_versions = []
       version_rules.each do |version_rule|
         case version_rule[0].to_sym
-        when :equals, :eq
+        when :equals, :eq, :matches
           supported_versions += available_version_definitions.versions_array.select { |av| av == parse_version(version_rule[1]) }
         when :ne
           supported_versions += available_version_definitions.versions_array.reject { |av| av == parse_version(version_rule[1]) }


### PR DESCRIPTION
…