### PR TITLE
Issue #43: When an objects source is not found, fields included may be rendered wrongly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.10.9 `(2020-02-21)`
+Fix issue #43: When an objects source is not found, fields included may be rendered wrongly
+
 ## 0.10.8 `(2020-01-13)`
 Support array parameters using comma separated or [] syntax
  

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'flappi'
-  s.version     = '0.10.8'
-  s.date        = '2020-01-13'
+  s.version     = '0.10.9'
+  s.date        = '2020-02-21'
   s.summary     = 'Flappi API Builder'
   s.description = 'A flexible DSL-based API builder'
   s.authors     = ['Richard Parratt', 'Sharesight']

--- a/lib/flappi/definition.rb
+++ b/lib/flappi/definition.rb
@@ -30,6 +30,8 @@ module Flappi
     # Use on {#field} and {#param} types when a boolean type is wanted and falsey values will be false, truthy true
     BOOLEAN_STRICT = :boolean_strict
 
+    SOURCE_PRESENT = :source_present
+
     # @private
     attr_reader :delegate
     # @private
@@ -151,7 +153,7 @@ module Flappi
     #   @option options [Object] :value the object to extract fields from
     #   @option options [Object] :source the name of a hash or method in the current source to get the data from, instead of :name
     #   @option options [Boolean] :inline_always rather than creating this object's hash, inline its fields into the parent
-    #   @option options [Boolean] :when if false, omit this object
+    #   @option options [Boolean] :when if false, omit this object, if SOURCE_PRESENT, omit unless a data source is present
     #   @option options [Hash] :version specify a versioning rule as a hash (see #version for spec for the rule). If present, this object will only we shown if the rule is met.
     #   @option options [String] :dynamic_key Rather than a fixed name, specify a key that is valid at request time.
     #   @yield A block that will be called to generate the response fields using nested {#field}, {#object} and {#objects} elements.
@@ -178,7 +180,7 @@ module Flappi
     #   @param name (String) the name of the array field
     #   @param value (Object) either an array, in which case each value will become a result entry, or a scalar which will produce a single result.
     #   @option options [Boolean] :compact remove nil entries from the result array
-    #   @option options [Boolean] :when if false, omit this object
+    #   @option options [Boolean] :when if false, omit this object, if SOURCE_PRESENT, omit unless a data source is present
     #   @option options [Hash] :version specify a versioning rule as a hash (see #version for spec for the rule). If present, this object will only we shown if the rule is met.
     #   @option options [Boolean] :hashed - produce a hash rather than a collection. The hash key is defined with {#hash_key}
     #   @yield A block that will be called to generate the response fields using nested {#field}, {#object} and {#objects} elements. The block will be called for each array value in sequence.
@@ -190,7 +192,7 @@ module Flappi
     #   @option options [Object] :value either an array, in which case each value will become a result entry, or a scalar which will produce a single result.
     #   @option options [Object] :source the name of a hash or method in the current source to get the data array from, instead of :name
     #   @option options [Boolean] :compact remove nil entries from the result array
-    #   @option options [Boolean] :when if false, omit this object
+    #   @option options [Boolean] :when if false, omit this object, if SOURCE_PRESENT, omit unless a data source is present
     #   @option options [Hash] :version specify a versioning rule as a hash (see #version for spec for the rule). If present, this object will only we shown if the rule is met.
     #   @option options [Boolean] :hashed - produce a hash rather than a collection. The hash key is defined with {#hash_key}
     #   @yield A block that will be called to generate the response fields using nested {#field}, {#object} and {#objects} elements.
@@ -222,7 +224,7 @@ module Flappi
     #   @option options [String] :name the name of the field
     #   @option options [Object] :value if given, the value to output
     #   @option options [Object] :source the name of a hash or method in the current source to get the data from, instead of :name
-    #   @option options [Boolean] :when if false, omit this object
+    #   @option options [Boolean] :when if false, omit this object, if SOURCE_PRESENT, omit unless a data source is present
     #   @option options [Hash] :version specify a versioning rule as a hash (see #version for spec for the rule). If present, this field will only we shown if the rule is met.
     #   @option options [String] :doc_name where a field has a dynamic name (computed value) then use this value, enclosed in underscores, as the name of the field.
     #   @option options [String] :type a type to coerce the value to: :Integer, :BigDecimal, :Float
@@ -238,12 +240,12 @@ module Flappi
     # @overload hash_key(value, options={})
     #   Define the hash key as having a specified value
     #   @param value (Object) the value for the hash key
-    #   @option options [Boolean] :when if false, omit this object
+    #   @option options [Boolean] :when if false, omit this object, if SOURCE_PRESENT, omit unless a data source is present
     #
     # @overload hash_key(options={})
     #   Define the hash key with named options
     #   @option options [Object] :value if given, the value to output
-    #   @option options [Boolean] :when if false, omit this object
+    #   @option options [Boolean] :when if false, omit this object, if SOURCE_PRESENT, omit unless a data source is present
     #
     def hash_key(*args, &block)
       @delegate.hash_key(*args, block)

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -56,6 +56,10 @@ module Flappi
                       else
                         options[:type].send(as_method, permitted_params)
                       end
+      else
+        # We have no query, so all methods use e.g constant values
+        # so we define it as an empty hash
+        base_object = {}
       end
 
       # If return_error called, return a struct
@@ -97,17 +101,18 @@ module Flappi
     # creating its fields inside the block
     def object(*args_or_name, block)
       def_args = extract_definition_args(args_or_name)
-      return if def_args.key?(:when) && !def_args[:when]
+      new_source = field_value(def_args)
+      return unless check_when(def_args, new_source)
       return unless version_wanted(def_args)
 
       @source_stack.push(@current_source)
-      @current_source = field_value(def_args) || @current_source
+      @current_source = new_source || @current_source
 
       if def_args.key?(:name) || def_args.key?(:dynamic_key)
         @put_stack.push(@put_stack.last[def_args[:dynamic_key] || def_args[:name]] = new_h)
         @link_stack.push([])
 
-        block.call @current_source
+        block.call(@current_source)
 
         put_links
         @put_stack.pop
@@ -129,10 +134,11 @@ module Flappi
     def objects(*args_or_name, block)
       def_args = extract_definition_args(args_or_name)
       require_arg def_args, :name
-      return if def_args.key?(:when) && !def_args[:when]
+      new_source = field_value(def_args) || @current_source
+      return unless check_when(def_args, new_source)
       return unless version_wanted(def_args)
 
-      values = field_value(def_args) || @current_source
+      values = new_source
       # puts "args_or_name=#{args_or_name},\n def_args=#{def_args}, objects=#{values}"
 
       @hash_stack.push(@hash_key ||= nil)
@@ -184,7 +190,7 @@ module Flappi
       def_args = extract_definition_args(args_or_name)
       require_arg def_args, :name
 
-      return if def_args.key?(:when) && !def_args[:when]
+      return unless check_when(def_args, @current_source)
       return unless version_wanted(def_args)
 
       value = field_value(def_args, block)
@@ -197,7 +203,7 @@ module Flappi
       # TODO: can't be nested
       def_args = extract_definition_args_nameless(args)
 
-      return if def_args.key?(:when) && !def_args[:when]
+      return unless check_when(def_args, @current_source)
       return unless version_wanted(def_args)
 
       @hash_key = field_value(def_args, block)
@@ -432,6 +438,16 @@ module Flappi
     end
 
     private
+
+    def check_when(def_args, source)
+      return true unless def_args.key?(:when)
+
+      if def_args[:when]&.is_a?(Symbol) && def_args[:when] == :source_present
+        return !!source
+      end
+
+      !!def_args[:when]
+    end
 
     def put_links
       link_defs = @link_stack.pop || []

--- a/lib/flappi/response_builder.rb
+++ b/lib/flappi/response_builder.rb
@@ -442,9 +442,7 @@ module Flappi
     def check_when(def_args, source)
       return true unless def_args.key?(:when)
 
-      if def_args[:when]&.is_a?(Symbol) && def_args[:when] == :source_present
-        return !!source
-      end
+      return !!source if def_args[:when]&.is_a?(Symbol) && def_args[:when] == :source_present
 
       !!def_args[:when]
     end

--- a/test/examples/exercise11_object_nest.rb
+++ b/test/examples/exercise11_object_nest.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Examples
+  module Exercise11
+    include Flappi::Definition
+
+    # Strictly to test which folder this came from.  This would not be in a real definition folder.
+    # see test/definition_locator_test.rb
+    def self.definition_source
+      'examples'
+    end
+
+    def endpoint
+      group 'Test_Exercise'
+      http_method 'GET'
+      path '/examples/exercise11'
+      title 'Exercise API 11'
+      description 'Exercise definition DSL #11'
+
+      param :include, type: BOOLEAN
+
+      query do |params|
+        if params[:include]
+          { a: 5,
+            instrument: {
+                code: 'AAA'
+            }
+          }
+        else
+          { a: 15 }
+        end
+      end
+    end
+
+    def respond
+      build do
+        field :a, type: Integer
+        object :instrument, when: SOURCE_PRESENT do
+          field :code
+        end
+      end
+    end
+  end
+end

--- a/test/examples/exercise11_object_nest.rb
+++ b/test/examples/exercise11_object_nest.rb
@@ -23,9 +23,8 @@ module Examples
         if params[:include]
           { a: 5,
             instrument: {
-                code: 'AAA'
-            }
-          }
+              code: 'AAA'
+            }}
         else
           { a: 15 }
         end

--- a/test/integration/exercise10_array_test.rb
+++ b/test/integration/exercise10_array_test.rb
@@ -30,7 +30,7 @@ module Integration
       should 'support array with comma separated args' do
         @controller.params = {'arr' => '2,4,6' }
         response = @controller.show
-        assert_equal( { 'arr' => [2, 4, 6] }, response)
+        assert_equal({ 'arr' => [2, 4, 6] }, response)
       end
 
       should 'pass literal commas in bracketed array' do

--- a/test/integration/exercise11_response_test.rb
+++ b/test/integration/exercise11_response_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require 'pp'
+
+require_relative '../examples/exercise11_object_nest'
+
+module Examples
+  class Exercise11Controller < ExampleController
+    def initialize
+      self.params = { }
+    end
+
+    def request
+      OpenStruct.new(query_parameters: params, url: 'http://test.api/exercise11')
+    end
+  end
+end
+
+module Integration
+  class Exercise11ResponseTest < MiniTest::Test
+    context 'Response to Exercise11' do
+      setup do
+        Flappi.configure do |conf|
+          conf.version_plan = nil
+        end
+
+        @controller = Examples::Exercise11Controller.new
+      end
+
+      should 'respond with instrument code when include true' do
+        @controller.params = { include: true }
+        response = @controller.show
+
+        assert_equal({ 'a' => 5, 'instrument' => { 'code' => 'AAA' } }, response)
+      end
+
+      should 'respond with nil instrument when include false' do
+        @controller.params = { include: false }
+        response = @controller.show
+
+        assert_equal({ 'a' => 15 }, response)
+      end
+    end
+  end
+end

--- a/test/response_builder_test.rb
+++ b/test/response_builder_test.rb
@@ -70,7 +70,7 @@ class ::Flappi::ResponseBuilderTest < MiniTest::Test
               @response_builder.field :a, 100, nil
             end
 
-            @response_builder.object(:my_object, object_block)
+            @response_builder.object({ name: :my_object, value: true}, object_block)
           end
 
           assert_equal({ 'my_object' => { 'a' => 100 } }, built_response)


### PR DESCRIPTION
Introduce the `when: SOURCE_PRESENT` to check for this.
(We can't make this always the case as quite a lot of code has no source and relies on a value being passed down explicitly)

#43 