### PR TITLE
Log errors (sent back to the API clients)

### DIFF
--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -281,7 +281,7 @@ module Flappi
       if response_object.respond_to?(:status_code)
         error_info = response_object.status_error_info
         response_hash = error_info.is_a?(String) ? { error: error_info } : { errors: error_info }
-        controller.render json: response_hash.to_json, plain: error_info, status: response_object.status_code
+        controller.render json: response_hash.to_json, status: response_object.status_code
       else
         controller.render json: response_object, status: :ok
       end

--- a/lib/flappi/builder_factory.rb
+++ b/lib/flappi/builder_factory.rb
@@ -281,6 +281,7 @@ module Flappi
       if response_object.respond_to?(:status_code)
         error_info = response_object.status_error_info
         response_hash = error_info.is_a?(String) ? { error: error_info } : { errors: error_info }
+        Flappi::Utils::Logger.i "flappi error response: #{response_hash.inspect}"
         controller.render json: response_hash.to_json, status: response_object.status_code
       else
         controller.render json: response_object, status: :ok


### PR DESCRIPTION
We need to figure out why some API requests (i.e. trade creations) run into a `422 - unprocessable entity` error. This pull request enables logging of any error response we send back to the API client.

See [bug ticket](https://vimaly.com/#j8mqm/t/API_V2_Investigate_some_POST_trade_calls_returning.../P6Oezi85Jou2MHqbV) for more details.