### PR TITLE
Fix the Ruby warning about re-initializing the constant

### DIFF
--- a/lib/flappi/documenter.rb
+++ b/lib/flappi/documenter.rb
@@ -28,7 +28,9 @@ module Flappi
 
     def self.load_all_modules(from, top_module)
       Flappi::Utils::Logger.d "Loading from #{from} : #{top_module}"
-      Dir.glob("#{from}/**/*.rb") do |file|
+      Dir.glob("#{from}/**/*.rb").sort
+         .map { |file| File.expand_path(file) }
+         .each do |file|
         expected_klass = begin
           Module.const_get("#{top_module}::#{File.basename(file, '.*').camelize}")
         rescue StandardError
@@ -37,9 +39,7 @@ module Flappi
         # The autoloader may load our module anyway here
 
         unless all_the_modules(top_module).include?(expected_klass)
-          # puts "loading #{file}"
-
-          load file
+          require file
         end
       end
     end


### PR DESCRIPTION
We see the following warning from investapp:

    warning: already initialized constant Api::V3::ApiBuilderDefinitions::Shared::Pagination::DEFAULT_PER_PAGE (called from <module:Pagination> at app/controllers/api/v3/api_builder_definitions/shared/pagination.rb:9)
    previous definition of DEFAULT_PER_PAGE was here (called from <module:Pagination> at app/controllers/api/v3/api_builder_definitions/shared/pagination.rb:9)

This warning is from Ruby when we re-assign a constant, which often happens when we use `load` instead of `require` to load a file.

The warning can be found here:
* https://app.bugsnag.com/sharesight/sharesight/errors/60eb840266a53b00078abb04
* https://app.bugsnag.com/sharesight/sharesight/errors/60ef9bd618715f0008e8d40f

The difference between `load` and `require` can be found here: https://medium.com/@gooddb67/ruby-load-vs-require-vs-include-b6bf3c71e049

PR: https://github.com/sharesight/flappi/pull/49
Vimaly: https://vimaly.com/#j8mqm/t/Ruby_2.7_Fix_Ruby_warning_about_re-initialize_cons.../SFxQqPYwAEa0CIc7g