### PR TITLE
Raise errors on deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ Lint/BinaryOperatorWithIdenticalOperands:
   Exclude:
     - 'test/**/*.rb'
 
+Lint/DuplicateBranch:
+  Enabled: false
+
 Lint/EmptyBlock:
   Enabled: false
 

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-performance', '1.9.0'
   s.add_development_dependency 'shoulda-context'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'warning'
   s.add_development_dependency 'yard'
 end

--- a/test/helpers/warning_test_helper.rb
+++ b/test/helpers/warning_test_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'warning'
+
+Warning.process do |warning|
+  case warning
+  when /instance variable .* not initialized/
+    :default
+  when /warning:/
+    :raise
+  else
+    :default
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,9 @@ require 'mocha/minitest'
 require 'pry'
 require 'flappi'
 
+# Requiring custom test helpers
+Dir["#{File.dirname(__FILE__)}/helpers/*.rb"].sort.each { |f| require File.expand_path(f) }
+
 Flappi.configure do |conf|
   conf.definition_paths = {
     'v2.0' => 'examples',


### PR DESCRIPTION
Ruby 2.7 introduce a couple of deprecation warnings around [positional and keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), in preparation for Ruby 3. So far we only showed the deprecation warning (when running tests for example). Not anymore, because we missed some of them already. We now raise an exception in that case, so you have to fix them before they sneak into investapp.