### PR TITLE
Address image deprecation from 2020

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       ruby-version:
         type: string
     docker:
-      - image: circleci/ruby:<< parameters.ruby-version >>
+      - image: cimg/ruby:<< parameters.ruby-version >>
 
     steps:
       - checkout


### PR DESCRIPTION
Vimaly [story](https://vimaly.com/#j8mqm/t/CircleCI_image_deprecation/g2FEASLzcsVyW154h)

Drop in replacement as described here:
https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/