### PR TITLE
Migrate from CircleCI to Github Actions for tests and linting

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,16 +27,3 @@ jobs:
 
     - name: Run rubocop
       run: bundle exec rubocop --parallel
-
-    - name: Slack notification
-      if: success() || failure()
-      uses: rtCamp/action-slack-notify@v2
-      env:
-         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
-         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
-         SLACK_ICON_EMOJI: ':sharesight_cat:'
-         SLACK_TITLE: "Linter run with Rubocop *${{ job.status }}* (by ${{ github.actor }})"
-         SLACK_USERNAME: GA rubocop
-         SLACK_FOOTER: ''
-         MSG_MINIMAL: actions url,commit

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Linters
+
+on:
+  push
+
+permissions:
+  contents: read
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+    - name: Run rubocop
+      run: bundle exec rubocop --parallel
+
+    - name: Slack notification
+      if: success() || failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
+         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
+         SLACK_ICON_EMOJI: ':sharesight_cat:'
+         SLACK_TITLE: "Linter run with Rubocop *${{ job.status }}* (by ${{ github.actor }})"
+         SLACK_USERNAME: GA rubocop
+         SLACK_FOOTER: ''
+         MSG_MINIMAL: actions url,commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,16 +31,3 @@ jobs:
 
     - name: Run tests
       run: bundle exec rake test
-
-    - name: Slack notification
-      if: success() || failure()
-      uses: rtCamp/action-slack-notify@v2
-      env:
-         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
-         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
-         SLACK_ICON_EMOJI: ':sharesight_cat:'
-         SLACK_TITLE: "Test run with ruby ${{matrix.ruby-version}} *${{ job.status }}* (by ${{ github.actor }})"
-         SLACK_USERNAME: GA tests
-         SLACK_FOOTER: ''
-         MSG_MINIMAL: actions url,commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Tests
+
+on:
+  push
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7.1', '2.7.3']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+    - name: Run tests
+      run: bundle exec rake test
+
+    - name: Slack notification
+      if: success() || failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
+         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
+         SLACK_ICON_EMOJI: ':sharesight_cat:'
+         SLACK_TITLE: "Test run with ruby ${{matrix.ruby-version}} *${{ job.status }}* (by ${{ github.actor }})"
+         SLACK_USERNAME: GA tests
+         SLACK_FOOTER: ''
+         MSG_MINIMAL: actions url,commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+ * Run tests and Rubocop with Github Actions [#55](https://github.com/sharesight/flappi/pull/55)
+ * Address CircleCI Ruby image deprecation [#54](https://github.com/sharesight/flappi/pull/54)
+ * Skip file generation if `#skip_docs` method present [#53](https://github.com/sharesight/flappi/pull/53)
+ * Raise on deprecation warnings [#52](https://github.com/sharesight/flappi/pull/52)
+ * Remove support for Ruby 2.6 [#51](https://github.com/sharesight/flappi/pull/51)
+ * Update links in README.md [#50](https://github.com/sharesight/flappi/pull/50)
+
 ## 0.10.12 `(2021-07-21)`
 
 * Fix the Ruby warning about re-initializing the constant [#49])(https://github.com/sharesight/flappi/pull/49)


### PR DESCRIPTION
### 📝 Description

Added GA workflows to run tests and Rubocop (another copy + paste from https://github.com/sharesight/validators/pull/9).

----

Related:
- https://github.com/sharesight/anonymisation/pull/206
- https://github.com/sharesight/broker_transactions_import/pull/305
- https://github.com/sharesight/continuous_worker/pull/10
- https://github.com/sharesight/data_sources/pull/194
- https://github.com/sharesight/encrypted_strings/pull/6
- https://github.com/sharesight/flappi/pull/55 (this PR)
- https://github.com/sharesight/jemquarie/pull/14
- TODO: pdf_parser coming soon
- https://github.com/sharesight/sharesight_rds/pull/26
- https://github.com/sharesight/sharesight_utils/pull/30
- https://github.com/sharesight/validators/pull/9