### PR TITLE
Add Slack notification to GA workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,3 +27,17 @@ jobs:
 
     - name: Run rubocop
       run: bundle exec rubocop --parallel
+
+
+    - name: Slack notification
+      if: success() || failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
+         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
+         SLACK_ICON_EMOJI: ':sharesight_cat:'
+         SLACK_TITLE: "Linter run with Rubocop *${{ job.status }}* (by ${{ github.actor }})"
+         SLACK_USERNAME: GA rubocop
+         SLACK_FOOTER: ''
+         MSG_MINIMAL: actions url,commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,16 @@ jobs:
 
     - name: Run tests
       run: bundle exec rake test
+
+    - name: Slack notification
+      if: success() || failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
+         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
+         SLACK_ICON_EMOJI: ':sharesight_cat:'
+         SLACK_TITLE: "Test run with ruby ${{matrix.ruby-version}} *${{ job.status }}* (by ${{ github.actor }})"
+         SLACK_USERNAME: GA tests
+         SLACK_FOOTER: ''
+         MSG_MINIMAL: actions url,commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+ * Add Slack notification for 'tests' and 'linters' Github Actions workflows [#11](https://github.com/sharesight/flappi/pull/56)
  * Run tests and Rubocop with Github Actions [#55](https://github.com/sharesight/flappi/pull/55)
  * Address CircleCI Ruby image deprecation [#54](https://github.com/sharesight/flappi/pull/54)
  * Skip file generation if `#skip_docs` method present [#53](https://github.com/sharesight/flappi/pull/53)


### PR DESCRIPTION
### 📝 Description

I'd previously added tests and linters GA workflows in https://github.com/sharesight/flappi/pull/55, but couldn't get Slack notifications to work. 

I thought this was a limitation of public forks/repos, but I was wrong - there is an option under "Settings" (that I can't access 😅) that only allowed the `SLACK_WEBHOOK` to be available for private repos. (Credit goes to Kylor for updating this setting to now also allow public forks/repos and letting me know this is possible).

<img width="621" alt="Screen Shot 2022-07-28 at 11 00 11" src="https://user-images.githubusercontent.com/2127023/181386794-ed1515bd-21d6-4501-8cab-d2bf0569b3d1.png">

No story.

----

Related:
- (public repo) https://github.com/sharesight/flappi/pull/56 (this PR)
- (public fork) https://github.com/sharesight/jemquarie/pull/15
- (public fork) https://github.com/sharesight/encrypted_strings/pull/8