### PR TITLE
Replace use of `pry` with `debug`

### DIFF
--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport', '>4.2.7'
   s.add_runtime_dependency 'recursive-open-struct'
 
+  s.add_development_dependency 'debug'
   s.add_development_dependency 'maxitest', '~> 4'
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake', '>= 12.3'
   s.add_development_dependency 'rubocop', '1.59.0'
   s.add_development_dependency 'rubocop-minitest', '0.10.1'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,10 +7,10 @@ if ENV['COVERAGE_ME']
   SimpleCov.start
 end
 
+require 'debug'
 require 'maxitest/autorun'
 require 'shoulda-context'
 require 'mocha/minitest'
-require 'pry'
 require 'flappi'
 
 # Requiring custom test helpers


### PR DESCRIPTION
### 📝 Description

`pry` and `pry-byebug` no longer supported since Ruby 3.2.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/1205428368058391/1206747143994466/f