### PR TITLE
Update `flappi` dependencies for Rails 7.1

### DIFF
--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/sharesight/flappi'
   s.license = 'MIT'
 
-  s.add_runtime_dependency 'activesupport', '~> 7.1.0'
+  s.add_runtime_dependency 'activesupport', ">= 7.0", "< 7.2"
   s.add_runtime_dependency 'recursive-open-struct'
 
   s.add_development_dependency 'debug'

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/sharesight/flappi'
   s.license = 'MIT'
 
-  s.add_runtime_dependency 'activesupport', '~> 7.0.8'
+  s.add_runtime_dependency 'activesupport', '~> 7.1.0'
   s.add_runtime_dependency 'recursive-open-struct'
 
   s.add_development_dependency 'debug'


### PR DESCRIPTION
## Description
We want upgrade _investapp_ to Rails 7.1, and therefore need to update the `flappi` gem's dependencies accordingly. It now supports both Rails versions 7.0 and 7.1 .

See [Asana ticket](https://app.asana.com/0/1202486819364117/1207407464892063).