### PR TITLE
Bump version of flappi to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.0 `(2026-03-27)`
+
+ * Bump activesupport to v8.0 for flappi [#68](https://github.com/sharesight/flappi/pull/68)
+
 ## 1.2.0 `(2025-08-25)`
 
  * Update dependencies for Rails 7.2 [#67](https://github.com/sharesight/flappi/pull/67)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ To release a new version of the `flappi` gem follow this checklist:
 
     ```sh
     # in flappi
-    vi lib/flappi/version.rb
+    vi flappi.gemspec
 
     # change version and describe your changes
     vi CHANGELOG.md

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'flappi'
-  s.version     = '1.2.0'
+  s.version     = '1.3.0'
   s.summary     = 'Flappi API Builder'
   s.description = 'A flexible DSL-based API builder'
   s.authors     = ['Richard Parratt', 'Sharesight']


### PR DESCRIPTION
Note that I have also included a small change to the `CONTRIBUTING.md` to account for where the version number is stored.