### PR TITLE
Support Rails 8.1.x

### DIFF
--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/sharesight/flappi'
   s.license = 'MIT'
 
-  s.add_dependency 'activesupport', ">= 7.0", "< 8.1"
+  s.add_dependency 'activesupport', ">= 7.0", "< 8.2"
   s.add_dependency 'recursive-open-struct'
 
   s.add_development_dependency 'debug'


### PR DESCRIPTION
We need to support the latest Rails / ActiveSupport versions so that we can update investapp.

We have run through the [Rails 8.1 release notes](https://guides.rubyonrails.org/8_1_release_notes.html) with Claude and verified that none of the changes affect the flappi gem. The full test suite passes against ActiveSupport 8.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
