### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.1 `(2026-07-16)`
+
+ * Support Rails 8.1.x [#70](https://github.com/sharesight/flappi/pull/70)
+
 ## 1.3.0 `(2026-03-27)`
 
  * Bump activesupport to v8.0 for flappi [#68](https://github.com/sharesight/flappi/pull/68)

--- a/flappi.gemspec
+++ b/flappi.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'flappi'
-  s.version     = '1.3.0'
+  s.version     = '1.3.1'
   s.summary     = 'Flappi API Builder'
   s.description = 'A flexible DSL-based API builder'
   s.authors     = ['Richard Parratt', 'Sharesight']


### PR DESCRIPTION
## 1.3.1 `(2026-07-16)`

 * Support Rails 8.1.x [#70](https://github.com/sharesight/flappi/pull/70)
